### PR TITLE
:hammer: check enhancement and start supporting for `sh`

### DIFF
--- a/release-image.fish
+++ b/release-image.fish
@@ -1,9 +1,11 @@
 #!/bin/fish
 
-set git_v (git describe --abbrev=8 --always --dirty='*')
+set app_v (grep -m 1 -oP '^\s*version\s*=\s*"\K[^"]+' Cargo.toml; or echo "unknown")
+set git_v (command -q git; and git describe --abbrev=8 --always --dirty='*' 2>/dev/null; or echo "unknown")
 
 echo '-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-'
 echo -e "\033[1;34mR\033[0met 2 \033[1;31mS\033[0mhell OCI Distribution Script\n"
+echo -e "App version: \033[1;32m$app_v\033[0m"
 echo -e "Build on commit: \033[1;32m$git_v\033[0m"
 
 if command -q docker

--- a/release-image.fish
+++ b/release-image.fish
@@ -5,8 +5,7 @@ set git_v (command -q git; and git describe --abbrev=8 --always --dirty='*' 2>/d
 
 echo '-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-'
 echo -e "\033[1;34mR\033[0met 2 \033[1;31mS\033[0mhell OCI Distribution Script\n"
-echo -e "App version: \033[1;32m$app_v\033[0m"
-echo -e "Build on commit: \033[1;32m$git_v\033[0m"
+echo -e "Build on version: \033[1;32m$app_v-$git_v\033[0m"
 
 if command -q docker
     set buildkit docker

--- a/release-image.sh
+++ b/release-image.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+command_t() {
+    if command -v "$1" 2>&1 >/dev/null; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+x1b=$(printf '\033')
+
+# version info
+app_v="$(grep -m 1 -oP '^\s*version\s*=\s*"\K[^"]+' Cargo.toml 2>/dev/null || echo "unknown")"
+git_v="$(command_t git && git describe --abbrev=8 --always --dirty='*' 2>/dev/null || echo "unknown")"
+echo '-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-'
+echo "${x1b}[1;34mR${x1b}[0met 2 ${x1b}[1;31mS${x1b}[0mhell OCI Distribution Script" && echo
+echo "App version: ${x1b}[1;32m$app_v${x1b}[0m"
+echo "Build on commit: ${x1b}[1;32m$git_v${x1b}[0m"
+
+# prepare build command
+buildkit=""
+build_args=""
+
+if command_t docker; then
+    buildkit=docker
+elif command_t podman; then
+    buildkit=podman
+    build_args="--format docker"
+elif command_t buildah; then
+    buildkit=buildah
+    build_args="--format docker"
+else
+    echo "No image buildkit found"
+    exit 1
+fi
+
+echo "Building image with ${x1b}[1;32m$buildkit${x1b}[0m"
+echo "-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-" && echo
+$buildkit build $build_args --build-arg R2S_GIT_VERSION=$git_v -t ret2shell:latest -f Containerfile .

--- a/release-image.sh
+++ b/release-image.sh
@@ -15,8 +15,7 @@ app_v="$(grep -m 1 -oP '^\s*version\s*=\s*"\K[^"]+' Cargo.toml 2>/dev/null || ec
 git_v="$(command_t git && git describe --abbrev=8 --always --dirty='*' 2>/dev/null || echo "unknown")"
 echo '-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-'
 echo "${x1b}[1;34mR${x1b}[0met 2 ${x1b}[1;31mS${x1b}[0mhell OCI Distribution Script" && echo
-echo "App version: ${x1b}[1;32m$app_v${x1b}[0m"
-echo "Build on commit: ${x1b}[1;32m$git_v${x1b}[0m"
+echo "Build on version: ${x1b}[1;32m$app_v-$git_v${x1b}[0m"
 
 # prepare build command
 buildkit=""


### PR DESCRIPTION
Print app version by detecting [Cargo.toml](https://github.com/ret2shell/ret2shell/blob/main/Cargo.toml) (The first `version` property)
Check git command and add `unknown` to commit hash for non-git directory

e.g.
```plaintext
Ret 2 Shell OCI Distribution Script

App version: 3.4.4
Build on commit: unknown
Building image with docker
```

Support `.sh` script, just run with `/bin/sh` by `sh release-image.sh`.