### PR TITLE
:bug: use RichTitle with getter wrapper and template function (fix #66)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,7 +18,6 @@
     "rust-analyzer.showUnlinkedFileNotification": false,
     "javascript.format.enable": false,
     "typescript.format.enable": false,
-    "editor.formatOnSave": true,
     "editor.defaultFormatter": "biomejs.biome",
     "editor.codeActionsOnSave": {
         "source.organizeImports.biome": "explicit"
@@ -35,6 +34,9 @@
     "i18n-ally.localesPaths": ["web/src/lib/i18n"],
     "i18n-ally.keystyle": "nested",
     "[typescript]": {
+        "editor.defaultFormatter": "biomejs.biome"
+    },
+    "[typescriptreact]": {
         "editor.defaultFormatter": "biomejs.biome"
     }
 }

--- a/web/src/lib/blocks/challenge/scripts/dynamic-uuid.rx
+++ b/web/src/lib/blocks/challenge/scripts/dynamic-uuid.rx
@@ -9,7 +9,7 @@ const WITH_HYPHEN = true;
 /// whether the flag uuid is case sensitive
 const CASE_SENSITIVE  = true;
 /// the key to initialize the flag encryptor
-const ENCRYPT_KEY = "Ave_mujija";
+const ENCRYPT_KEY = "Ave_mujica";
 /// the flag prefix, maybe the game name, `flag` means the flag will be `flag{...}`
 const PREFIX = "flag";
 /// the flag hash key, used to generate the uuid content

--- a/web/src/lib/blocks/game/statistics.tsx
+++ b/web/src/lib/blocks/game/statistics.tsx
@@ -1,20 +1,19 @@
+import { handleHttpError } from "@api";
 import { type GameStatisticsExport, getGameStatistics, getGameStatisticsExport } from "@api/game";
-import { gameStore } from "@storage/game";
-import { t } from "@storage/theme";
-import { createEffect, createMemo, createSignal, Show, untrack } from "solid-js";
-import { platformStore } from "@storage/platform";
-import { Title } from "@storage/header";
-import logo from "@assets/logo.svg";
-import { mediaPath } from "@lib/utils/media";
-import Divider from "@widgets/divider";
 import Spin from "@assets/animates/spin";
-import Chart from "@widgets/chart";
+import logo from "@assets/logo.svg";
+import XLSX from "@e965/xlsx";
+import { mediaPath } from "@lib/utils/media";
 import { accountStore, refreshInstitutes } from "@storage/account";
 import { challengeStore, refreshChallenges } from "@storage/challenge";
+import { gameStore } from "@storage/game";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import Button from "@widgets/button";
+import Chart from "@widgets/chart";
+import Divider from "@widgets/divider";
 import Select from "@widgets/select";
-import XLSX from "@e965/xlsx";
-import { handleHttpError } from "@api";
+import { Show, createEffect, createMemo, createSignal, untrack } from "solid-js";
 
 export default function GameStatistics(props: {
   inGame?: boolean;
@@ -208,7 +207,7 @@ export default function GameStatistics(props: {
 
   return (
     <>
-      <Title title={`${t("game.statistics.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("game.statistics.title")} - ${E("platform.name")}`} />
       <div class="flex-1 flex flex-col p-3 lg:p-6 gap-3 lg:gap-6 w-full">
         <div class="hidden xl:flex items-center justify-start space-x-12 px-12">
           <img class="w-24 h-24" src={gameStore.current?.logo ? mediaPath(gameStore.current!.logo) : logo} alt="CTF" />

--- a/web/src/lib/storage/header.ts
+++ b/web/src/lib/storage/header.ts
@@ -52,7 +52,10 @@ class RichTitle {
   }
 
   toString() {
-    const _Args = this.args.map((arg) => arg?.toString() || String(arg));
+    const _Args = this.args.map((arg) => {
+      if (typeof arg === "undefined" || arg === null) return String(arg);
+      return Object.prototype.hasOwnProperty.call(arg, "toString") ? arg.toString() : String(arg);
+    });
     return this.raw.reduce((acc, val, idx) => {
       return acc + val + (_Args[idx] || "");
     }, "");
@@ -62,6 +65,7 @@ class RichTitle {
     if (title instanceof RichTitle) {
       return title.toString();
     }
+    if (typeof title === "undefined" || title === null) return String(title);
     return Object.prototype.hasOwnProperty.call(title, "toString") ? title.toString() : String(title);
   }
 }
@@ -135,6 +139,7 @@ export function Title(props: { title: string | DynamicElement | RichTitle }) {
   } else {
     headerStore.insertRoute(pathArr, RichTitle.from(props.title));
   }
+  document.title = RichTitle.toString(props.title);
   return null;
 }
 

--- a/web/src/lib/storage/header.ts
+++ b/web/src/lib/storage/header.ts
@@ -1,70 +1,158 @@
+import { DynamicElement } from "@lib/utils/dynamic-record";
 import { useLocation } from "@solidjs/router";
 import { createEffect, untrack } from "solid-js";
 import { platformStore } from "./platform";
 import { t } from "./theme";
 
+class RichTitle {
+  raw: TemplateStringsArray;
+  args: (string | DynamicElement)[];
+  /**
+   * Template string with dynamic elements.
+   */
+  constructor(raw: TemplateStringsArray, args: (string | DynamicElement)[]) {
+    this.raw = raw;
+    this.args = args;
+  }
+
+  /**
+   * The template function, same usage as `String.raw`.
+   *
+   * @example
+   * ```ts
+   * RichTitle.fromTemplate`Hello, ${"world"}!` // "Hello, world!"
+   * ```
+   * @example
+   * ```ts
+   * let i = 0;
+   * const record = new DynamicRecord({
+   *   "a": () => [0, ++i]
+   * });
+   * const E = record.createElement.bind(record);
+   * RichTitle.fromTemplate`Output: ${E("a")}!` // "Output: 0,1!"
+   * ```
+   */
+  static fromTemplate(raw: TemplateStringsArray, ...args: unknown[]) {
+    return new RichTitle(raw, args as (string | DynamicElement)[]);
+  }
+
+  /**
+   * From a string, or a DynamicElement, or a RichTitle.
+   */
+  static from(o: string | DynamicElement | RichTitle) {
+    if (o instanceof RichTitle) {
+      return new RichTitle(o.raw, o.args);
+    }
+    if (o instanceof DynamicElement) {
+      return RichTitle.fromTemplate`${o}`;
+    }
+    const raw = [RichTitle.toString(o)];
+    Object.defineProperty(raw, "raw", { value: Array.from(raw), writable: false });
+    return new RichTitle(Object.freeze(raw) as TemplateStringsArray, []);
+  }
+
+  toString() {
+    const _Args = this.args.map((arg) => arg?.toString() || String(arg));
+    return this.raw.reduce((acc, val, idx) => {
+      return acc + val + (_Args[idx] || "");
+    }, "");
+  }
+
+  static toString(title: string | DynamicElement | RichTitle) {
+    if (title instanceof RichTitle) {
+      return title.toString();
+    }
+    return Object.prototype.hasOwnProperty.call(title, "toString") ? title.toString() : String(title);
+  }
+}
+
+/**
+ * Template string generator for RichTitle
+ */
+export function tmpl(raw: TemplateStringsArray, ...args: unknown[]) {
+  return new RichTitle(raw, args as (string | DynamicElement)[]);
+}
+
 class RouteHeader {
-  title: string;
+  title?: RichTitle;
   path: string;
   subRoutes: RouteHeader[];
   constructor() {
-    this.title = "";
-    this.path = "";
+    this.title = undefined;
+    this.path = "(root)";
     this.subRoutes = [];
   }
 
-  /// returns: [parentRoute, exactRoute]
+  /**
+   * @returns ```
+   * [parentRoute, exactRoute]
+   * ```
+   */
   findRoute(subPath: string[]): [RouteHeader, RouteHeader | null] {
-    if (subPath.length === 0) {
-      return [this, this];
+    let parent: RouteHeader = this;
+    let current: RouteHeader = this;
+    for (const pathnode of subPath) {
+      const next = current.subRoutes.find((r) => r.path === pathnode);
+      if (next) {
+        parent = next;
+        current = next;
+      } else {
+        return [parent, null];
+      }
     }
-    const subRoute = this.subRoutes.find((r) => r.path === subPath[0]);
-    if (subRoute) {
-      return subRoute.findRoute(subPath.slice(1));
-    }
-    return [this, null];
+    return [parent, current];
   }
 
-  insertRoute(subPath: string[], title: string) {
-    if (subPath.length === 0) {
-      this.title = title;
-      return;
+  insertRoute(subPath: string[], title: RichTitle) {
+    let current: RouteHeader = this;
+    for (let i = 0; i < subPath.length; i++) {
+      const pathnode = subPath[i];
+      const next = current.subRoutes.find((r) => r.path === pathnode);
+      if (next) {
+        current = next;
+      } else {
+        const newRoute = new RouteHeader();
+        newRoute.path = pathnode;
+        current.subRoutes.push(newRoute);
+        current = newRoute;
+      }
     }
-    const subRoute = this.subRoutes.find((r) => r.path === subPath[0]);
-    if (subRoute) {
-      subRoute.insertRoute(subPath.slice(1), title);
-    } else {
-      const newRoute = new RouteHeader();
-      newRoute.path = subPath[0];
-      newRoute.insertRoute(subPath.slice(1), title);
-      this.subRoutes.push(newRoute);
-    }
+    current.title = title;
+    return current;
   }
 }
 
 export const headerStore = new RouteHeader();
 
-export function Title(props: { title: string }) {
-  const path = useLocation().pathname;
+/// React component
+export function Title(props: { title: string | DynamicElement | RichTitle }) {
+  let path = useLocation().pathname;
+  if (path.endsWith("/")) path = path.slice(0, path.length - 1);
   const pathArr = path.split("/");
   const [, exactRoute] = headerStore.findRoute(pathArr);
   if (exactRoute) {
-    exactRoute.title = props.title;
+    exactRoute.title = RichTitle.from(props.title);
   } else {
-    headerStore.insertRoute(pathArr, props.title);
+    headerStore.insertRoute(pathArr, RichTitle.from(props.title));
   }
   return null;
+}
+
+export function resolveTitle(pathname: string) {
+  const path = pathname.endsWith("/") ? pathname.slice(0, pathname.length - 1) : pathname;
+  const pathArr = path.split("/");
+  const [parentRoute, exactRoute] = headerStore.findRoute(pathArr);
+  document.title = RichTitle.toString(
+    exactRoute?.title || parentRoute.title || platformStore.config.name || t("platform.name")!
+  );
 }
 
 export function setupTitleResolver() {
   const watchedLocation = useLocation();
   createEffect(() => {
-    let path = watchedLocation.pathname;
+    const path = watchedLocation.pathname;
     untrack(() => {
-      if (path.endsWith("/")) path = path.slice(0, path.length - 1);
-      const pathArr = path.split("/");
-      const [parentRoute, exactRoute] = headerStore.findRoute(pathArr);
-      document.title = exactRoute?.title || parentRoute.title || platformStore.config.name || t("platform.name")!;
+      resolveTitle(path);
     });
   });
 }

--- a/web/src/lib/storage/theme.ts
+++ b/web/src/lib/storage/theme.ts
@@ -3,6 +3,7 @@ import { DynamicRecord } from "@lib/utils/dynamic-record";
 import { resolveTemplate, translator } from "@solid-primitives/i18n";
 import { createPrefersDark } from "@solid-primitives/media";
 import { makePersisted } from "@solid-primitives/storage";
+import { gameStore } from "@storage/game";
 import { createEffect, createResource, untrack } from "solid-js";
 import { createStore } from "solid-js/store";
 import { platformStore } from "./platform";
@@ -87,6 +88,7 @@ export const colorPalette = {
 
 const dynamicRecord = new DynamicRecord({
   "platform.name": () => platformStore.config.name || t("platform.name"),
+  "gamestore.current.name": () => gameStore.current?.name,
 });
 
 export const j = dynamicRecord.dynamicJson();

--- a/web/src/lib/storage/theme.ts
+++ b/web/src/lib/storage/theme.ts
@@ -1,9 +1,11 @@
 import { type Locale, fetchDictionary, hasLocale } from "@lib/i18n";
+import { DynamicRecord } from "@lib/utils/dynamic-record";
 import { resolveTemplate, translator } from "@solid-primitives/i18n";
 import { createPrefersDark } from "@solid-primitives/media";
 import { makePersisted } from "@solid-primitives/storage";
 import { createEffect, createResource, untrack } from "solid-js";
 import { createStore } from "solid-js/store";
+import { platformStore } from "./platform";
 
 const prefersDark = createPrefersDark();
 
@@ -82,3 +84,10 @@ export const colorPalette = {
   warning: "#db640e",
   error: "#e05864",
 };
+
+const dynamicRecord = new DynamicRecord({
+  "platform.name": () => platformStore.config.name || t("platform.name"),
+});
+
+export const j = dynamicRecord.dynamicJson();
+export const E = dynamicRecord.createElement.bind(dynamicRecord);

--- a/web/src/lib/utils/dynamic-record.ts
+++ b/web/src/lib/utils/dynamic-record.ts
@@ -3,21 +3,35 @@ type ReduceGetter<T extends Record<string, unknown>> = { [K in keyof T]: ReturnT
 
 export class DynamicElement<T extends Record<string, unknown> = { [k: string]: unknown }, K extends keyof T = keyof T> {
   key: K;
+  fallback: (DynamicElement<T, K> | ReduceGetter<T>[K])[];
   /**
    * Wrapper of the value of the record.
+   *
+   * @param fallback Given same final type of `k`, or the `Element` object
    */
-  constructor(k: K) {
+  constructor(k: K, ...fallback: (DynamicElement<T, K> | ReduceGetter<T>[K])[]) {
     this.key = k;
+    this.fallback = fallback;
   }
   // implement this
   get(): ReduceGetter<T>[K] {
-    return this.key as ReduceGetter<T>[K];
+    let t = this.key as ReduceGetter<T>[K];
+    for (const v of this.fallback) {
+      if (!t) break;
+      if (v instanceof DynamicElement) {
+        t = v.get();
+      } else {
+        t = v;
+      }
+    }
+    return t;
   }
   valueOf() {
     return this.get();
   }
   toString() {
     const t = this.get();
+    if (typeof t === "undefined" || t === null) return String(t);
     return Object.prototype.hasOwnProperty.call(t, "toString") ? t!.toString() : String(t);
   }
 }
@@ -96,7 +110,7 @@ export class DynamicRecord<G extends Record<string, unknown>> {
    * console.log(element.toString()); // "0,3"
    * ```
    */
-  createElement<K extends keyof G>(key: K) {
-    return new this.Element(key) as DynamicElement<G, K>;
+  createElement<K extends keyof G>(key: K, ...fallback: (DynamicElement<G, K> | ReduceGetter<G>[K])[]) {
+    return new this.Element(key, ...fallback) as DynamicElement<G, K>;
   }
 }

--- a/web/src/lib/utils/dynamic-record.ts
+++ b/web/src/lib/utils/dynamic-record.ts
@@ -1,0 +1,102 @@
+type ReturnTypeOrSelf<T> = T extends () => unknown ? ReturnType<T> : T;
+type ReduceGetter<T extends Record<string, unknown>> = { [K in keyof T]: ReturnTypeOrSelf<T[K]> };
+
+export class DynamicElement<T extends Record<string, unknown> = { [k: string]: unknown }, K extends keyof T = keyof T> {
+  key: K;
+  /**
+   * Wrapper of the value of the record.
+   */
+  constructor(k: K) {
+    this.key = k;
+  }
+  // implement this
+  get(): ReduceGetter<T>[K] {
+    return this.key as ReduceGetter<T>[K];
+  }
+  valueOf() {
+    return this.get();
+  }
+  toString() {
+    const t = this.get();
+    return Object.prototype.hasOwnProperty.call(t, "toString") ? t!.toString() : String(t);
+  }
+}
+
+export class DynamicRecord<G extends Record<string, unknown>> {
+  protected getter: G;
+  readonly Element: typeof DynamicElement<G>;
+
+  /**
+   * DynamicRecord is a class that transforms a record of getter functions into a record of values,
+   * allowing use simple `[]` phrase to get the value of the record dynamically.
+   */
+  constructor(getters: G = {} as G) {
+    this.getter = getters;
+    const that = this;
+    this.Element = class extends DynamicElement<G> {
+      get() {
+        return DynamicRecord.valOrReturnVal(that.getter[this.key]);
+      }
+    };
+  }
+
+  protected static valOrReturnVal<T>(t: T) {
+    return (typeof t === "function" ? t() : t) as ReturnTypeOrSelf<T>;
+  }
+
+  protected static parseGetter<T extends Record<string, unknown>>(getters: T) {
+    return new Proxy(getters, {
+      get(target, prop, receiver) {
+        if (typeof prop === "string" && Object.prototype.hasOwnProperty.call(target, prop)) {
+          return DynamicRecord.valOrReturnVal(Reflect.get(target, prop, receiver));
+        }
+        return undefined;
+      },
+    }) as ReduceGetter<T>;
+  }
+
+  /**
+   * @example
+   * ```ts
+   * let i = 0;
+   * const record = new DynamicRecord({
+   *   "a": () => [0, ++i],
+   *   "b": () => "hello",
+   *   "c": 114514,
+   *   "d": "world"
+   * });
+   * const j = record.dynamicJson();
+   * console.log(j.a); // [0, 1]
+   * console.log(j.a); // [0, 2]
+   * console.log(j.b); // "hello"
+   */
+  dynamicJson() {
+    return DynamicRecord.parseGetter(this.getter);
+  }
+
+  /**
+   * Get the value of the record by key.
+   */
+  get(key: string) {
+    return DynamicRecord.valOrReturnVal(this.getter[key]) as ReturnTypeOrSelf<G[keyof G]>;
+  }
+
+  /**
+   * Create a DynamicElement instance by key. The element is a wrapper of the value of the record.
+   *
+   * @example
+   * ```ts
+   * let i = 0;
+   * const record = new DynamicRecord({
+   *  "a": () => [0, ++i]
+   * });
+   * const element = record.createElement("a");
+   * console.log(element.get()); // [0, 1]
+   * console.log(element.get()); // [0, 2]
+   * console.log(element.toString()); // "0,3"
+   * ```
+   */
+  createElement<K extends keyof G>(key: K) {
+    return new this.Element(key) as DynamicElement<G, K>;
+  }
+}

--- a/web/src/routes/account/bind/index.tsx
+++ b/web/src/routes/account/bind/index.tsx
@@ -1,15 +1,14 @@
+import { handleHttpError } from "@api";
 import { bindWithOAuth } from "@api/account";
 import LogoAnimate from "@assets/animates/logo-animate";
+import { getLogo } from "@assets/brands";
 import xdsecMascotHappy from "@assets/imgs/xdsec-mascot-happy.webp";
+import logo from "@assets/logo-gray.svg";
 import { useLocation, useNavigate, useSearchParams } from "@solidjs/router";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import LoadingTips from "@widgets/loading-tips";
 import { createSignal, onMount } from "solid-js";
-import logo from "@assets/logo-gray.svg";
-import { getLogo } from "@assets/brands";
-import { handleHttpError } from "@api";
 
 export default function () {
   const [animate, setAnimate] = createSignal(false);
@@ -43,7 +42,7 @@ export default function () {
 
   return (
     <div class="flex-1 w-full flex flex-col space-y-8 items-center justify-center">
-      <Title title={`${t("account.bind.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("account.bind.title")} - ${E("platform.name")}`} />
       <div class="flex flex-row space-x-8 items-center">
         <LogoAnimate
           width={128}

--- a/web/src/routes/account/forgot/index.tsx
+++ b/web/src/routes/account/forgot/index.tsx
@@ -3,9 +3,8 @@ import { forgotPassword } from "@api/account";
 import Captcha from "@blocks/captcha";
 import { createForm, email, minLength, required } from "@modular-forms/solid";
 import { useNavigate } from "@solidjs/router";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import { addToast } from "@storage/toast";
 import Button from "@widgets/button";
 import Card from "@widgets/card";
@@ -53,7 +52,7 @@ export default function () {
   }
   return (
     <div class="flex-1 flex flex-col items-center md:justify-center p-3 md:p-6">
-      <Title title={`${t("account.forgot.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("account.forgot.title")} - ${E("platform.name")}`} />
       <Card
         class="w-full max-w-md"
         contentClass="p-6 flex flex-col md:flex-row space-y-2 space-x-0 md:space-x-6 md:space-y-0"

--- a/web/src/routes/account/login/index.tsx
+++ b/web/src/routes/account/login/index.tsx
@@ -13,9 +13,8 @@ import type { AuthConfig } from "@models/config";
 import { createForm, minLength, pattern, required, setValue } from "@modular-forms/solid";
 import { A, useLocation, useNavigate } from "@solidjs/router";
 import { accountStore } from "@storage/account";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import { addToast } from "@storage/toast";
 import Button from "@widgets/button";
 import Card from "@widgets/card";
@@ -89,7 +88,7 @@ export default function () {
   }
   return (
     <>
-      <Title title={`${t("account.login.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("account.login.title")} - ${E("platform.name")}`} />
       <div class="flex-1 flex flex-col items-center md:justify-center p-3 md:p-6">
         <Card
           class="w-full max-w-3xl"

--- a/web/src/routes/account/register/index.tsx
+++ b/web/src/routes/account/register/index.tsx
@@ -6,9 +6,8 @@ import Captcha from "@blocks/captcha";
 import { createForm, email, maxLength, minLength, pattern, required, setValue } from "@modular-forms/solid";
 import { useNavigate } from "@solidjs/router";
 import { accountStore } from "@storage/account";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import { addToast } from "@storage/toast";
 import Button from "@widgets/button";
 import Card from "@widgets/card";
@@ -58,7 +57,7 @@ export default function () {
 
   return (
     <>
-      <Title title={`${t("account.register.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("account.register.title")} - ${E("platform.name")}`} />
       <div class="flex-1 flex flex-col items-center md:justify-center p-3 md:p-6">
         <Card
           class="w-full max-w-3xl"

--- a/web/src/routes/account/reset/index.tsx
+++ b/web/src/routes/account/reset/index.tsx
@@ -4,9 +4,8 @@ import Captcha from "@blocks/captcha";
 import { createForm, email, minLength, pattern, required, setValue } from "@modular-forms/solid";
 import { useNavigate, useSearchParams } from "@solidjs/router";
 import { accountStore } from "@storage/account";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import { addToast } from "@storage/toast";
 import Button from "@widgets/button";
 import Card from "@widgets/card";
@@ -61,7 +60,7 @@ export default function () {
   }
   return (
     <div class="flex-1 flex flex-col items-center md:justify-center p-3 md:p-6">
-      <Title title={`${t("account.reset.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("account.reset.title")} - ${E("platform.name")}`} />
       <Card
         class="w-full max-w-md"
         contentClass="p-6 flex flex-col md:flex-row space-y-2 space-x-0 md:space-x-6 md:space-y-0"

--- a/web/src/routes/admin/captcha/index.tsx
+++ b/web/src/routes/admin/captcha/index.tsx
@@ -1,17 +1,16 @@
+import { handleHttpError } from "@api";
 import { getPlatformConfig, updatePlatformConfig } from "@api/platform";
 import type { CaptchaConfig, Config } from "@models/config";
+import { createForm, getValue, required, setValues } from "@modular-forms/solid";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import { addToast } from "@storage/toast";
 import Button from "@widgets/button";
 import Checkbox from "@widgets/checkbox";
 import Select from "@widgets/select";
 import Slider from "@widgets/slider";
-import { createForm, getValue, required, setValues } from "@modular-forms/solid";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
 import type { HTTPError } from "ky";
 import { createSignal, onMount } from "solid-js";
-import { handleHttpError } from "@api";
 
 export default function () {
   const [form, { Form, Field }] = createForm<CaptchaConfig>();
@@ -63,7 +62,7 @@ export default function () {
   }
   return (
     <>
-      <Title title={`${t("admin.captcha.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("admin.captcha.title")} - ${E("platform.name")}`} />
       <div class="flex-1 flex flex-col items-center p-3 lg:p-6">
         <Form onSubmit={onSubmit} class="w-full max-w-5xl flex flex-col space-y-2">
           <h3 class="h-12 flex items-center border-b border-b-layer-content/10 font-bold space-x-2">

--- a/web/src/routes/admin/cluster/index.tsx
+++ b/web/src/routes/admin/cluster/index.tsx
@@ -1,9 +1,8 @@
 import { handleHttpError } from "@api";
 import { getClusterConfig, getClusterNodes } from "@api/cluster";
 import Spin from "@assets/animates/spin";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import Button from "@widgets/button";
 import Divider from "@widgets/divider";
 import LoadingTips from "@widgets/loading-tips";
@@ -50,7 +49,7 @@ export default function () {
   const [shownNode, setShownNode] = createSignal(null as Node | null);
   return (
     <>
-      <Title title={`${t("admin.cluster.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("admin.cluster.title")} - ${E("platform.name")}`} />
       <div class="flex-1 flex flex-col p-3 lg:p-6">
         <div class="h-32 lg:h-48 flex flex-row items-center">
           <div class="h-full aspect-square flex items-center justify-center">

--- a/web/src/routes/admin/edit/index.tsx
+++ b/web/src/routes/admin/edit/index.tsx
@@ -1,17 +1,17 @@
-import Checkbox from "@widgets/checkbox";
+import { handleHttpError } from "@api";
 import { getPlatformConfig, updatePlatformConfig } from "@api/platform";
 import LogoAnimate from "@assets/animates/logo-animate";
 import type { Config } from "@models/config";
 import { createForm, custom, setValues } from "@modular-forms/solid";
-import { Title } from "@storage/header";
+import { Title, tmpl } from "@storage/header";
 import { platformStore, setPlatformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { E, t } from "@storage/theme";
 import { addToast } from "@storage/toast";
 import Button from "@widgets/button";
+import Checkbox from "@widgets/checkbox";
 import Input from "@widgets/input";
 import type { HTTPError } from "ky";
 import { createSignal, onMount } from "solid-js";
-import { handleHttpError } from "@api";
 
 type PlatformConfigForm = {
   name?: string;
@@ -83,7 +83,7 @@ export default function () {
   });
   return (
     <>
-      <Title title={`${t("admin.edit.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("admin.edit.title")} - ${E("platform.name")}`} />
       <div class="flex-1 flex flex-col items-center p-3 lg:p-6">
         <Form onSubmit={onSubmit} class="w-full max-w-5xl flex flex-col space-y-2">
           <div class="p-6 flex items-center justify-center">

--- a/web/src/routes/admin/email/index.tsx
+++ b/web/src/routes/admin/email/index.tsx
@@ -2,9 +2,8 @@ import { handleHttpError } from "@api";
 import { getPlatformConfig, updatePlatformConfig } from "@api/platform";
 import type { Config, EmailConfig } from "@models/config";
 import { createForm, custom, getValue, setValues } from "@modular-forms/solid";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import { addToast } from "@storage/toast";
 import Button from "@widgets/button";
 import Checkbox from "@widgets/checkbox";
@@ -54,7 +53,7 @@ export default function () {
 
   return (
     <>
-      <Title title={`${t("admin.email.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("admin.email.title")} - ${E("platform.name")}`} />
       <div class="flex-1 flex flex-col items-center p-3 lg:p-6">
         <Form onSubmit={onSubmit} class="w-full max-w-5xl flex flex-col space-y-2">
           <h3 class="h-12 flex items-center border-b border-b-layer-content/10 font-bold space-x-2">

--- a/web/src/routes/admin/layout.tsx
+++ b/web/src/routes/admin/layout.tsx
@@ -1,10 +1,9 @@
-import { Permission } from "@models/user";
 import SidebarLayout from "@blocks/sidebar-layout";
+import { Permission } from "@models/user";
 import { useNavigate } from "@solidjs/router";
 import { accountStore } from "@storage/account";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import { addToast } from "@storage/toast";
 import type { JSX } from "solid-js";
 import SideBar from "./_blocks/sidebar";
@@ -26,7 +25,7 @@ export default function (props: { children?: JSX.Element }) {
   }
   return (
     <>
-      <Title title={`${t("admin.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("admin.title")} - ${E("platform.name")}`} />
       <SidebarLayout leftBar={() => <SideBar />}>{props.children}</SidebarLayout>
     </>
   );

--- a/web/src/routes/admin/logs/index.tsx
+++ b/web/src/routes/admin/logs/index.tsx
@@ -2,9 +2,8 @@ import { api_root, handleHttpError } from "@api";
 import { getPlatformLogs } from "@api/platform";
 import DownloadButton from "@blocks/download-button";
 import { accountStore } from "@storage/account";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import { addToast } from "@storage/toast";
 import Button from "@widgets/button";
 import LoadingTips from "@widgets/loading-tips";
@@ -119,7 +118,7 @@ export default function () {
   let bottomDiv: HTMLDivElement;
   return (
     <>
-      <Title title={`${t("admin.logs.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("admin.logs.title")} - ${E("platform.name")}`} />
       <div class="flex-1 flex flex-col">
         <div class="sticky top-16 h-16 z-20 backdrop-blur border-b border-b-layer-content/10 flex flex-row space-x-4 items-center px-3 lg:px-6">
           <h1 class="flex-1 font-bold flex flex-row space-x-2 items-center">

--- a/web/src/routes/admin/media/index.tsx
+++ b/web/src/routes/admin/media/index.tsx
@@ -2,9 +2,8 @@ import { handleHttpError } from "@api";
 import { getPlatformConfig, updatePlatformConfig } from "@api/platform";
 import type { Config, MediaConfig } from "@models/config";
 import { createForm, setValues } from "@modular-forms/solid";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import { addToast } from "@storage/toast";
 import Button from "@widgets/button";
 import Checkbox from "@widgets/checkbox";
@@ -59,7 +58,7 @@ export default function () {
   }
   return (
     <>
-      <Title title={`${t("admin.media.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("admin.media.title")} - ${E("platform.name")}`} />
       <div class="flex-1 flex flex-col items-center p-3 lg:p-6">
         <Form onSubmit={onSubmit} class="w-full max-w-5xl flex flex-col space-y-2">
           <h3 class="h-12 flex items-center border-b border-b-layer-content/10 font-bold space-x-2">

--- a/web/src/routes/admin/oauth/index.tsx
+++ b/web/src/routes/admin/oauth/index.tsx
@@ -1,11 +1,12 @@
+import { handleHttpError } from "@api";
 import { createInstitute, deleteInstitute, updateInstitute } from "@api/account";
 import { getAuthConfig } from "@api/platform";
+import { getLogo } from "@assets/brands";
 import type { AuthConfig } from "@models/config";
 import type { Institute } from "@models/institute";
 import { accountStore, refreshInstitutes } from "@storage/account";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import { addToast } from "@storage/toast";
 import Button from "@widgets/button";
 import Card from "@widgets/card";
@@ -14,8 +15,6 @@ import Popover from "@widgets/popover";
 import type { HTTPError } from "ky";
 import { For, Show, createMemo, createSignal, onMount } from "solid-js";
 import InstituteForm from "./_blocks/form";
-import { getLogo } from "@assets/brands";
-import { handleHttpError } from "@api";
 
 export default function () {
   const [authConfig, setAuthConfig] = createSignal({
@@ -82,7 +81,7 @@ export default function () {
   }
   return (
     <>
-      <Title title={`${t("admin.oauth.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("admin.oauth.title")} - ${E("platform.name")}`} />
       <div class="flex-1 flex flex-col items-center p-3 lg:p-6">
         <div class="w-full max-w-5xl flex flex-col">
           <h3 class="h-12 flex items-center border-b border-b-layer-content/10 font-bold space-x-2">

--- a/web/src/routes/admin/statistics/index.tsx
+++ b/web/src/routes/admin/statistics/index.tsx
@@ -3,9 +3,8 @@ import { type PlatformStatistics, getPlatformStatistics } from "@api/platform";
 import LogoAnimate from "@assets/animates/logo-animate";
 import Spin from "@assets/animates/spin";
 import { HostType } from "@models/game";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, j, t } from "@storage/theme";
 import Chart from "@widgets/chart";
 import Divider from "@widgets/divider";
 import { DateTime } from "luxon";
@@ -26,11 +25,11 @@ export default function () {
 
   return (
     <>
-      <Title title={`${t("admin.statistics.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("admin.statistics.title")} - ${E("platform.name")}`} />
       <div class="flex-1 grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 p-3 lg:p-6 gap-3 lg:gap-6">
         <div class="hidden xl:flex xl:col-span-2 items-center justify-start space-x-12 px-12">
           <LogoAnimate class="w-36 h-36" />
-          <h1 class="text-5xl font-bold">{platformStore.config.name || t("platform.name")!}</h1>
+          <h1 class="text-5xl font-bold">{j["platform.name"]}</h1>
         </div>
         <div class="col-span-1 h-48 p-6 flex flex-row items-center space-x-8">
           <div class="flex-1 flex flex-col space-y-4">

--- a/web/src/routes/admin/sync/index.tsx
+++ b/web/src/routes/admin/sync/index.tsx
@@ -1,12 +1,11 @@
 import NotImplemented from "@blocks/not-implemented";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 
 export default function () {
   return (
     <>
-      <Title title={`${t("admin.sync.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("admin.sync.title")} - ${E("platform.name")}`} />
       <div class="flex-1 flex items-center justify-center">
         <NotImplemented />
       </div>

--- a/web/src/routes/admin/users/index.tsx
+++ b/web/src/routes/admin/users/index.tsx
@@ -1,11 +1,11 @@
+import { handleHttpError } from "@api";
 import { getUser, getUserList, updateUser } from "@api/user";
 import { mediaPath } from "@lib/utils/media";
 import { type User, permissionToIcon } from "@models/user";
 import { A, useSearchParams } from "@solidjs/router";
 import { accountStore, refreshInstitutes } from "@storage/account";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import { addToast } from "@storage/toast";
 import Avatar from "@widgets/avatar";
 import Input from "@widgets/input";
@@ -15,7 +15,6 @@ import Select from "@widgets/select";
 import Tag from "@widgets/tag";
 import { For, Show, createEffect, createMemo, createSignal, onMount, untrack } from "solid-js";
 import Form from "./_blocks/form";
-import { handleHttpError } from "@api";
 
 type OrderType = "id" | "account" | "institute_id" | "registered_at";
 
@@ -207,7 +206,7 @@ export default function () {
   });
   return (
     <div class="flex-1 flex flex-col items-center">
-      <Title title={`${t("admin.users.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("admin.users.title")} - ${E("platform.name")}`} />
       <Show when={inEdit()} fallback={<UserList />}>
         <Form editSource={user() || undefined} onDone={handleUpdateUser} loading={updatingUser()} />
       </Show>

--- a/web/src/routes/bulletin/index.tsx
+++ b/web/src/routes/bulletin/index.tsx
@@ -5,9 +5,8 @@ import { randomTips } from "@lib/utils/loading-tips";
 import type { Article } from "@models/article";
 import { Permission } from "@models/user";
 import { accountStore } from "@storage/account";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import Divider from "@widgets/divider";
 import Link from "@widgets/link";
 import Pagination from "@widgets/pagination";
@@ -34,7 +33,7 @@ export default function () {
   });
   return (
     <>
-      <Title title={`${t("bulletin.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("bulletin.title")} - ${E("platform.name")}`} />
       <div class="flex flex-col items-center p-3 lg:p-6 flex-1">
         <div class="flex flex-col flex-1 w-full max-w-5xl">
           <div class="h-12 relative flex flex-row items-center px-4">

--- a/web/src/routes/docs/article.tsx
+++ b/web/src/routes/docs/article.tsx
@@ -1,7 +1,7 @@
 import Spin from "@assets/animates/spin";
 import { useLocation, useNavigate } from "@solidjs/router";
-import { Title } from "@storage/header";
-import { t, themeStore } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t, themeStore } from "@storage/theme";
 import Article from "@widgets/article";
 import Divider from "@widgets/divider";
 import { Show, createEffect, createSignal } from "solid-js";
@@ -61,7 +61,7 @@ export default function () {
   });
   return (
     <>
-      <Title title={`${title()} - ${t("platform.name")}`} />
+      <Title title={tmpl`${title()} - ${E("platform.name")}`} />
       <div class="flex-1 flex flex-col items-center px-3 lg:px-6">
         <h1 class="text-3xl flex flex-row space-x-4 items-center w-full max-w-5xl justify-start print:justify-center font-bold mt-8 print:mt-16">
           <Show

--- a/web/src/routes/docs/index.tsx
+++ b/web/src/routes/docs/index.tsx
@@ -1,10 +1,10 @@
-import { Title } from "@storage/header";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 
 export default function () {
   return (
     <>
-      <Title title={`${t("docs.title")} - ${t("platform.name")}`} />
+      <Title title={tmpl`${t("docs.title")} - ${E("platform.name")}`} />
       <div class="flex-1 flex flex-col items-center justify-center space-y-8 opacity-60">
         <span class="icon-[fluent-emoji-flat--hammer-and-wrench] w-24 h-24" />
         <span>{t("docs.title")}</span>

--- a/web/src/routes/games/[game]/admin/layout.tsx
+++ b/web/src/routes/games/[game]/admin/layout.tsx
@@ -3,7 +3,7 @@ import { createBreakpoints } from "@solid-primitives/media";
 import { useNavigate } from "@solidjs/router";
 import { gameStore, isGameAdmin } from "@storage/game";
 import { Title } from "@storage/header";
-import { t } from "@storage/theme";
+import { E, t } from "@storage/theme";
 import Button from "@widgets/button";
 import { type JSX, Show, createEffect, createSignal } from "solid-js";
 import { Transition } from "solid-transition-group";
@@ -26,7 +26,7 @@ export default function (props: { children?: JSX.Element }) {
   const [showSidebar, setShowSidebar] = createSignal(false);
   return (
     <>
-      <Title title={`${t("game.admin.title")} - ${gameStore.current?.name || "CTF"}`} />
+      <Title title={`${t("game.admin.title")} - ${E("gamestore.current.name", "CTF")}`} />
       <SidebarLayout leftBar={() => <SideBar />} showLeftBar={showSidebar()}>
         {props.children}
       </SidebarLayout>

--- a/web/src/routes/games/[game]/challenges/index.tsx
+++ b/web/src/routes/games/[game]/challenges/index.tsx
@@ -7,7 +7,7 @@ import { useNavigate, useSearchParams } from "@solidjs/router";
 import { accountStore } from "@storage/account";
 import { gameStore, isGameAdmin } from "@storage/game";
 import { Title } from "@storage/header";
-import { t } from "@storage/theme";
+import { E, t } from "@storage/theme";
 import Link from "@widgets/link";
 import LoadingTips from "@widgets/loading-tips";
 
@@ -121,7 +121,7 @@ export default function () {
   const [showRightSidebar, setShowRightSidebar] = createSignal(false);
   return (
     <>
-      <Title title={`${t("game.challenge.title")} - ${gameStore.current?.name || "CTF"}`} />
+      <Title title={`${t("game.challenge.title")} - ${E("gamestore.current.name", "CTF")}`} />
       <SidebarLayout
         showLeftBar={showLeftSidebar()}
         leftBar={() => (

--- a/web/src/routes/games/[game]/challenges/index.tsx
+++ b/web/src/routes/games/[game]/challenges/index.tsx
@@ -19,12 +19,12 @@ import Notifications from "./_blocks/notifications";
 import Team from "./_blocks/team";
 import Welcome from "./_blocks/welcome";
 
+import { handleHttpError } from "@api";
 import Tabs from "@blocks/challenge/tabs";
 import { createBreakpoints } from "@solid-primitives/media";
 import { challengeStore, refreshChallengeAssets, refreshChallenges, setChallengeStore } from "@storage/challenge";
 import Button from "@widgets/button";
 import { Transition } from "solid-transition-group";
-import { handleHttpError } from "@api";
 
 export default function () {
   const navigate = useNavigate();

--- a/web/src/routes/games/[game]/index.tsx
+++ b/web/src/routes/games/[game]/index.tsx
@@ -18,7 +18,7 @@ import {
   setGameStore,
 } from "@storage/game";
 import { Title } from "@storage/header";
-import { t } from "@storage/theme";
+import { E, t } from "@storage/theme";
 import { addToast } from "@storage/toast";
 import Article from "@widgets/article";
 import Button from "@widgets/button";
@@ -28,12 +28,12 @@ import Picture from "@widgets/picture";
 import Tag from "@widgets/tag";
 import Timer from "@widgets/timer";
 
+import { handleHttpError } from "@api";
 import bgGameDefault from "@assets/imgs/bg-game-default.webp";
 import { useSearchParams } from "@solidjs/router";
 import { DateTime } from "luxon";
 import { For, Match, Show, Switch, createEffect, createSignal, onCleanup, untrack } from "solid-js";
 import IntroForm from "./_blocks/intro-form";
-import { handleHttpError } from "@api";
 
 export default function () {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -205,7 +205,7 @@ export default function () {
 
   return (
     <>
-      <Title title={gameStore.current?.name || "CTF"} />
+      <Title title={E("gamestore.current.name", "CTF")} />
       <div class="flex-1 flex flex-col lg:flex-row-reverse">
         <div class="lg:w-1/3 max-h-[calc(100vh-4rem)] lg:sticky lg:top-16 lg:left-0 flex flex-col backdrop-blur border-b border-b-layer-content/10 lg:border-b-0 lg:backdrop-blur-none p-3 lg:p-6 space-y-2">
           <Card contentClass="relative">

--- a/web/src/routes/games/[game]/layout.tsx
+++ b/web/src/routes/games/[game]/layout.tsx
@@ -1,15 +1,15 @@
+import { handleHttpError } from "@api";
 import { getGame } from "@api/game";
 import { HostType } from "@models/game";
-import { useNavigate, useParams } from "@solidjs/router";
+import { useLocation, useNavigate, useParams } from "@solidjs/router";
+import { refreshInstitutes } from "@storage/account";
 import { setChallengeStore } from "@storage/challenge";
-import { gameStore, refreshSelfTeam, setGameStore } from "@storage/game";
-import { Title } from "@storage/header";
+import { refreshSelfTeam, setGameStore } from "@storage/game";
+import { Title, resolveTitle } from "@storage/header";
+import { E, t } from "@storage/theme";
 import { HTTPError } from "ky";
 import { type JSX, onCleanup, onMount } from "solid-js";
 import TeamCover from "./_blocks/team-cover";
-import { refreshInstitutes } from "@storage/account";
-import { handleHttpError } from "@api";
-import { t } from "@storage/theme";
 
 export default function (props: { children?: JSX.Element }) {
   const navigate = useNavigate();
@@ -17,6 +17,7 @@ export default function (props: { children?: JSX.Element }) {
     setGameStore({ current: null, preload: null, team: null, showTeamCover: false });
     setChallengeStore({ current: null, challenges: [], solves: [] });
   });
+  const location = useLocation();
   const params = useParams();
   const game_id = Number.parseInt(params.game);
   onMount(async () => {
@@ -28,6 +29,7 @@ export default function (props: { children?: JSX.Element }) {
           return null;
         }
         setGameStore({ current: resp });
+        resolveTitle(location.pathname);
         setTimeout(() => {
           refreshSelfTeam();
         });
@@ -43,7 +45,7 @@ export default function (props: { children?: JSX.Element }) {
 
   return (
     <>
-      <Title title={gameStore.current?.name || "CTF"} />
+      <Title title={E("gamestore.current.name", "CTF")} />
       {props.children}
       <TeamCover />
     </>

--- a/web/src/routes/games/[game]/scoreboard/index.tsx
+++ b/web/src/routes/games/[game]/scoreboard/index.tsx
@@ -1,3 +1,4 @@
+import { handleHttpError } from "@api";
 import { getGameScoreboard } from "@api/game";
 import type { Team } from "@models/team";
 import { createBreakpoints } from "@solid-primitives/media";
@@ -16,7 +17,6 @@ import { Match, Show, Switch, createEffect, createMemo, createSignal, onMount, u
 import TeamDetails from "./_blocks/team-details";
 import TeamRanks from "./_blocks/team-ranks";
 import TeamSolves from "./_blocks/team-solves";
-import { handleHttpError } from "@api";
 
 function ChartOperations(props: {
   onRefresh?: () => void;

--- a/web/src/routes/games/[game]/scoreboard/index.tsx
+++ b/web/src/routes/games/[game]/scoreboard/index.tsx
@@ -8,7 +8,7 @@ import { accountStore } from "@storage/account";
 import { challengeStore, refreshChallenges } from "@storage/challenge";
 import { canAccessChallenges, gameStore, inArchived } from "@storage/game";
 import { Title } from "@storage/header";
-import { t } from "@storage/theme";
+import { E, t } from "@storage/theme";
 import Button from "@widgets/button";
 import Card from "@widgets/card";
 import Chart from "@widgets/chart";
@@ -204,7 +204,7 @@ export default function () {
 
   return (
     <>
-      <Title title={`${t("game.scoreboard.title")} - ${gameStore.current?.name || "CTF"}`} />
+      <Title title={`${t("game.scoreboard.title")} - ${E("gamestore.current.name", "CTF")}`} />
       <div class="flex flex-col xl:flex-row flex-1 min-w-min">
         <div ref={autoPageSizeWatcher!} class="fixed h-[calc(100vh-24rem)]" />
         <Show when={topTeams().length > 0}>

--- a/web/src/routes/games/[game]/teams/create/index.tsx
+++ b/web/src/routes/games/[game]/teams/create/index.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from "@solidjs/router";
 import { accountStore } from "@storage/account";
 import { canParticipate, gameParticipateState, gameStore, setGameStore } from "@storage/game";
 import { Title } from "@storage/header";
-import { t, themeStore } from "@storage/theme";
+import { E, t, themeStore } from "@storage/theme";
 import { addToast } from "@storage/toast";
 import Article from "@widgets/article";
 import Button from "@widgets/button";
@@ -72,7 +72,7 @@ export default function () {
   const [dialogOpen, setDialogOpen] = createSignal(false);
   return (
     <>
-      <Title title={`${t("game.team.create.title")} - ${gameStore.current?.name || "CTF"}`} />
+      <Title title={`${t("game.team.create.title")} - ${E("gamestore.current.name", "CTF")}`} />
       <div class="flex-1 flex flex-col items-center md:justify-center p-3 md:p-6">
         <Card
           class="w-full max-w-xl"

--- a/web/src/routes/games/[game]/teams/join/index.tsx
+++ b/web/src/routes/games/[game]/teams/join/index.tsx
@@ -4,7 +4,7 @@ import { createForm, required, setValue } from "@modular-forms/solid";
 import { useNavigate } from "@solidjs/router";
 import { canParticipate, gameParticipateState, gameStore, setGameStore } from "@storage/game";
 import { Title } from "@storage/header";
-import { t, themeStore } from "@storage/theme";
+import { E, t, themeStore } from "@storage/theme";
 import { addToast } from "@storage/toast";
 import Article from "@widgets/article";
 import Button from "@widgets/button";
@@ -59,7 +59,7 @@ export default function () {
   const [dialogOpen, setDialogOpen] = createSignal(false);
   return (
     <>
-      <Title title={`${t("game.team.join.title")} - ${gameStore.current?.name || "CTF"}`} />
+      <Title title={`${t("game.team.join.title")} - ${E("gamestore.current.name", "CTF")}`} />
       <div class="flex-1 flex flex-col items-center md:justify-center p-3 md:p-6">
         <Card
           class="w-full max-w-xl"

--- a/web/src/routes/games/layout.tsx
+++ b/web/src/routes/games/layout.tsx
@@ -1,7 +1,6 @@
 import { setGameStore } from "@storage/game";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import { type JSX, onCleanup } from "solid-js";
 import Cover from "./_blocks/cover";
 
@@ -11,7 +10,7 @@ export default function (props: { children?: JSX.Element }) {
   });
   return (
     <>
-      <Title title={`${t("game.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("game.title")} - ${E("platform.name")}`} />
       {props.children}
       <Cover />
     </>

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -3,7 +3,7 @@ import LogoAnimate from "@assets/animates/logo-animate";
 import { useSearchParams } from "@solidjs/router";
 import { Title } from "@storage/header";
 import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { E, j, t } from "@storage/theme";
 import Button from "@widgets/button";
 import Card from "@widgets/card";
 import Link from "@widgets/link";
@@ -30,14 +30,14 @@ export default function () {
   });
   return (
     <>
-      <Title title={platformStore.config.name || t("platform.name")!} />
+      <Title title={E("platform.name")} />
       <div class="flex-1 relative">
         <div class="absolute h-full w-full overflow-scroll snap-mandatory snap-y">
           <section class="h-full min-h-full snap-center flex flex-col items-center justify-center relative">
             <div class="flex-1" />
             <h1 class="text-3xl font-bold opacity-80">
               &nbsp;&nbsp;
-              <span>[&nbsp;{platformStore.config.name || t("platform.name")}&nbsp;]</span>
+              <span>[&nbsp;{j["platform.name"]}&nbsp;]</span>
               &nbsp;
               <span class="text-primary animate-ping">_</span>
             </h1>

--- a/web/src/routes/layout.tsx
+++ b/web/src/routes/layout.tsx
@@ -1,3 +1,4 @@
+import { handleHttpError } from "@api";
 import { getPlatformInfo, getPlatformLicense, getVersion } from "@api/platform";
 import LogoAnimate from "@assets/animates/logo-animate";
 import Background from "@blocks/background";
@@ -8,9 +9,9 @@ import { Permission } from "@models/user";
 import { useLocation, useNavigate, useParams, useSearchParams } from "@solidjs/router";
 import { accountStore } from "@storage/account";
 import { canAccessChallenges, gameStore, inProgress, isGameAdmin } from "@storage/game";
-import { setupTitleResolver } from "@storage/header";
+import { resolveTitle, setupTitleResolver } from "@storage/header";
 import { frontendCompatVersion, platformStore, setPlatformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { j, t } from "@storage/theme";
 import { addToast, removeToast, toastStore } from "@storage/toast";
 import Button from "@widgets/button";
 import Card from "@widgets/card";
@@ -24,12 +25,11 @@ import { HTTPError } from "ky";
 import { DateTime } from "luxon";
 import { type JSX, Match, Show, Switch, createEffect, createMemo, createSignal, onMount, untrack } from "solid-js";
 import { Transition } from "solid-transition-group";
-import ThemeBox, { ThemeBoxContent } from "./_blocks/theme-box";
 import InstanceBox, { InstanceBoxContent } from "./_blocks/instance-box";
 import NotificationBox, { NotificationBoxContent } from "./_blocks/notification-box";
+import ThemeBox, { ThemeBoxContent } from "./_blocks/theme-box";
 import Toasts from "./_blocks/toasts";
 import UserBox from "./_blocks/user-box";
-import { handleHttpError } from "@api";
 
 function GlobalTitleLink() {
   const location = useLocation();
@@ -38,9 +38,7 @@ function GlobalTitleLink() {
     <Link ghost href={inDocs() ? "/docs" : "/"}>
       <LogoAnimate class="hidden xl:inline-block" width={24} height={24} />
       <span />
-      <span>
-        {inDocs() ? `${t("docs.title")} - ${t("platform.name")}` : platformStore.config.name || t("platform.name")}
-      </span>
+      <span>{inDocs() ? `${t("docs.title")} - ${j["platform.name"]}` : j["platform.name"]}</span>
     </Link>
   );
 }
@@ -177,7 +175,7 @@ function TitleBar() {
     <>
       <div id="page-top" class="print:hidden" />
       <div class="hidden print:flex flex-row border-b border-b-layer-content/60 w-full">
-        <span>{inDocs() ? t("docs.titleTips") : platformStore.config.name || t("platform.name")}</span>
+        <span>{inDocs() ? t("docs.titleTips") : j["platform.name"]}</span>
         <span class="flex-1" />
         <span>{DateTime.now().toFormat("yyyy-MM-dd HH:mm:ss")}</span>
       </div>
@@ -395,7 +393,7 @@ function checkCookiePolicy() {
 }
 
 export default function (props: { children?: JSX.Element }) {
-  let platformName = `\xa0\xa0[\xa0${platformStore.config.name || t("platform.name")}\xa0]\xa0`;
+  let platformName = `\xa0\xa0[\xa0${j["platform.name"]}\xa0]\xa0`;
   const [platformTyped, setPlatformTyped] = createSignal("");
   const [hideAnimation, setHideAnimation] = createSignal(false);
   const showAnimation = useLocation().pathname === "/" && useSearchParams()[0].event === undefined;
@@ -423,6 +421,7 @@ export default function (props: { children?: JSX.Element }) {
         config: res,
         backend_online: true,
       });
+      resolveTitle(location.pathname);
       loadVersion();
     } catch (err) {
       if (err instanceof HTTPError && err.response?.status === 503) {
@@ -446,7 +445,7 @@ export default function (props: { children?: JSX.Element }) {
       }
       setPlatformStore({ backend_online: false });
     }
-    platformName = `\xa0\xa0[\xa0${platformStore.config.name || t("platform.name")}\xa0]\xa0`;
+    platformName = `\xa0\xa0[\xa0${j["platform.name"]}\xa0]\xa0`;
 
     setTimeout(checkCookiePolicy, 1000);
 

--- a/web/src/routes/sigtrap/e401.tsx
+++ b/web/src/routes/sigtrap/e401.tsx
@@ -1,12 +1,11 @@
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import ErrorSection from "./error";
 
 export default function () {
   return (
     <>
-      <Title title={`${t("errors.401")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("errors.401")} - ${E("platform.name")}`} />
       <ErrorSection status={401} />
     </>
   );

--- a/web/src/routes/sigtrap/e403.tsx
+++ b/web/src/routes/sigtrap/e403.tsx
@@ -1,12 +1,11 @@
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import ErrorSection from "./error";
 
 export default function () {
   return (
     <>
-      <Title title={`${t("errors.403")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("errors.403")} - ${E("platform.name")}`} />
       <ErrorSection status={403} />
     </>
   );

--- a/web/src/routes/sigtrap/e404.tsx
+++ b/web/src/routes/sigtrap/e404.tsx
@@ -1,12 +1,11 @@
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import ErrorSection from "./error";
 
 export default function () {
   return (
     <>
-      <Title title={`${t("errors.404")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("errors.404")} - ${E("platform.name")}`} />
       <ErrorSection status={404} />
     </>
   );

--- a/web/src/routes/sigtrap/e412.tsx
+++ b/web/src/routes/sigtrap/e412.tsx
@@ -1,12 +1,11 @@
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import ErrorSection from "./error";
 
 export default function () {
   return (
     <>
-      <Title title={`${t("errors.412")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("errors.412")} - ${E("platform.name")}`} />
       <ErrorSection status={412} />
     </>
   );

--- a/web/src/routes/sigtrap/e418.tsx
+++ b/web/src/routes/sigtrap/e418.tsx
@@ -1,12 +1,11 @@
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import ErrorSection from "./error";
 
 export default function () {
   return (
     <>
-      <Title title={`${t("errors.418")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("errors.418")} - ${E("platform.name")}`} />
       <ErrorSection status={418} />
     </>
   );

--- a/web/src/routes/sigtrap/e500.tsx
+++ b/web/src/routes/sigtrap/e500.tsx
@@ -1,12 +1,11 @@
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import ErrorSection from "./error";
 
 export default function () {
   return (
     <>
-      <Title title={`${t("errors.500")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("errors.500")} - ${E("platform.name")}`} />
       <ErrorSection status={500} />
     </>
   );

--- a/web/src/routes/sigtrap/e502.tsx
+++ b/web/src/routes/sigtrap/e502.tsx
@@ -1,12 +1,11 @@
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import ErrorSection from "./error";
 
 export default function () {
   return (
     <>
-      <Title title={`${t("errors.502")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("errors.502")} - ${E("platform.name")}`} />
       <ErrorSection status={502} />
     </>
   );

--- a/web/src/routes/training/layout.tsx
+++ b/web/src/routes/training/layout.tsx
@@ -1,9 +1,8 @@
 import SidebarLayout from "@blocks/sidebar-layout";
 import { createBreakpoints } from "@solid-primitives/media";
 import { setGameStore } from "@storage/game";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import Button from "@widgets/button";
 import { type JSX, Show, createSignal, onCleanup } from "solid-js";
 import { Transition } from "solid-transition-group";
@@ -20,7 +19,7 @@ export default function (props: { children?: JSX.Element }) {
   const [showSidebar, setShowSidebar] = createSignal(false);
   return (
     <>
-      <Title title={`${t("training.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("training.title")} - ${E("platform.name")}`} />
       <SidebarLayout leftBar={() => <SideBar />} showLeftBar={showSidebar()}>
         {props.children}
       </SidebarLayout>

--- a/web/src/routes/users/[user]/index.tsx
+++ b/web/src/routes/users/[user]/index.tsx
@@ -1,16 +1,15 @@
+import { handleHttpError } from "@api";
 import { getUser, getUserTeams } from "@api/user";
 import SidebarLayout from "@blocks/sidebar-layout";
 import type { Team } from "@models/team";
 import type { User } from "@models/user";
 import { A, useNavigate, useParams } from "@solidjs/router";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import Article from "@widgets/article";
 import LoadingTips from "@widgets/loading-tips";
 import { For, Match, Switch, createEffect, createSignal, untrack } from "solid-js";
 import Sidebar from "./_blocks/sidebar";
-import { handleHttpError } from "@api";
 
 export default function () {
   const [user, setUser] = createSignal(null as null | User);
@@ -39,7 +38,7 @@ export default function () {
 
   return (
     <>
-      <Title title={`${user()?.nickname} - ${platformStore.config.name || t("platform.name")!}`} />
+      <Title title={tmpl`${user()?.nickname} - ${E("platform.name")}`} />
       <SidebarLayout leftBar={() => <Sidebar user={user()} loading={loading()} />}>
         <div class="flex-1 flex flex-col items-center p-3 lg:p-6">
           <div class="flex flex-col w-full max-w-5xl">

--- a/web/src/routes/wiki/[article]/index.tsx
+++ b/web/src/routes/wiki/[article]/index.tsx
@@ -1,12 +1,12 @@
+import { handleHttpError } from "@api";
 import { deleteWiki, getWiki } from "@api/wiki";
 import Spin from "@assets/animates/spin";
 import type { Article as ArticleModel } from "@models/article";
 import { Permission } from "@models/user";
 import { A, useNavigate, useParams, useSearchParams } from "@solidjs/router";
 import { accountStore } from "@storage/account";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import { addToast } from "@storage/toast";
 import { refreshWikiToc, setWikiStore, wikiStore } from "@storage/wiki";
 import Article from "@widgets/article";
@@ -14,7 +14,6 @@ import Divider from "@widgets/divider";
 import { HTTPError } from "ky";
 import { Show, createEffect, onCleanup, untrack } from "solid-js";
 import EditForm from "../_blocks/form";
-import { handleHttpError } from "@api";
 
 export default function () {
   const params = useParams();
@@ -74,7 +73,7 @@ export default function () {
   }
   return (
     <>
-      <Title title={`${wikiStore.current?.title} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${wikiStore.current?.title} - ${E("platform.name")}`} />
       <div class="flex-1 flex flex-col items-center px-3 lg:px-6">
         <h1 class="text-3xl flex flex-row space-x-4 items-center w-full max-w-5xl justify-start print:justify-center font-bold mt-8 print:mt-16">
           <Show

--- a/web/src/routes/wiki/create/index.tsx
+++ b/web/src/routes/wiki/create/index.tsx
@@ -1,8 +1,7 @@
 import type { Article } from "@models/article";
 import { useNavigate } from "@solidjs/router";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import { refreshWikiToc } from "@storage/wiki";
 import CreateForm from "../_blocks/form";
 
@@ -14,7 +13,7 @@ export default function () {
   }
   return (
     <>
-      <Title title={`${t("form.create")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("form.create")} - ${E("platform.name")}`} />
       <div class="flex-1 flex flex-col p-3 lg:p-6">
         <CreateForm onDone={onDone} />
       </div>

--- a/web/src/routes/wiki/layout.tsx
+++ b/web/src/routes/wiki/layout.tsx
@@ -1,8 +1,7 @@
 import SidebarLayout from "@blocks/sidebar-layout";
 import { createBreakpoints } from "@solid-primitives/media";
-import { Title } from "@storage/header";
-import { platformStore } from "@storage/platform";
-import { t } from "@storage/theme";
+import { Title, tmpl } from "@storage/header";
+import { E, t } from "@storage/theme";
 import { refreshWikiToc } from "@storage/wiki";
 import Button from "@widgets/button";
 import { type JSX, Show, createSignal } from "solid-js";
@@ -18,7 +17,7 @@ export default function (props: { children?: JSX.Element }) {
   refreshWikiToc();
   return (
     <>
-      <Title title={`${t("wiki.title")} - ${platformStore.config.name || t("platform.name")}`} />
+      <Title title={tmpl`${t("wiki.title")} - ${E("platform.name")}`} />
       <SidebarLayout leftBar={() => <SideBar />} showLeftBar={showSidebar()}>
         {props.children}
       </SidebarLayout>


### PR DESCRIPTION
# Fixes #66 title display bugs

We fixes #66 by taking following ideas.

## Type from `string` to `RichTitle`

Change type of `title` at class `RouteHeader`:
https://github.com/ret2shell/ret2shell/blob/b53b635e111591e8fee45d7e7144f339c0eb006e/web/src/lib/storage/header.ts#L76-L77

The declaration of `title` contains `?:` but not `:`. It's beacause we need dummy route node has empty title, in order that the `?.xxx` and ` || ` syntactic sugar can be taken at `ResolveTitle` function:

https://github.com/ret2shell/ret2shell/blob/b53b635e111591e8fee45d7e7144f339c0eb006e/web/src/lib/storage/header.ts#L145-L147

The class `RichTitle` stores the original materials of tag function (TemplateStringArray and arguments):

https://github.com/ret2shell/ret2shell/blob/b53b635e111591e8fee45d7e7144f339c0eb006e/web/src/lib/storage/header.ts#L7-L9

## Getter wrapper

We need a getter to calculate `platformStore.config.name || t("platform.name")` every time visited.

We take advantages of object `Proxy` and `getter` definition, which allows us to use `json["platform.name"]` (simple key-value usage) to get values not static.

We should prepare a JSON object which contains callable function value. i.e.

```javascript
{
  "date.now": () => { return Date.now() }
}
```

The `parseGetter` function would convert each `key-functional_value` to `key-getter_value`:

https://github.com/ret2shell/ret2shell/blob/b53b635e111591e8fee45d7e7144f339c0eb006e/web/src/lib/utils/dynamic-record.ts#L47-L56

**See example:**

```javascript
consr record = parseGetter({
  "date.now": () => { return Date.now() }
})
record["date.now"] // the time when visiting the value
```

The parameter `record` is a whole json. But in some case, we wanna tell the program that it is a getter but do not calculate it immediately, otherwise it has no difference than what without getter. For example, `` `${"foo"} - ${record["date.now"]}` `` is no different than `` `${"foo"} - ${Date.now()}` ``, but we want the whole string to be a getter.

Thus we create a element getter wrapper for a single value:

https://github.com/ret2shell/ret2shell/blob/b53b635e111591e8fee45d7e7144f339c0eb006e/web/src/lib/utils/dynamic-record.ts#L36-L39

And implements `toString` and `valueOf` method defaultly:

https://github.com/ret2shell/ret2shell/blob/b53b635e111591e8fee45d7e7144f339c0eb006e/web/src/lib/utils/dynamic-record.ts#L16-L22

Now we can use `${"foo"} - ${new Element["date.now"]}`, and we will calculate `date.now` later in tag function. The latest thing we shall do is to store the arguments of tag function, which is exactly class `RichTitle` does.

> ![NOTE]
> If the original getters json contains non `key-functional_value`, it would not convert but leave it as it is.
> That means that following snippets are correct:
> ```javascript
> consr record = parseGetter({
>   "date.now": () => { return Date.now() }
>   "static": [1, 2, 3]
> })
> ```
> record["date.now"] // the time when visiting the value
> record["static"] // [1, 2, 3]
> As for `Element`, the `toString` will call its `toString` if exists, otherwise (`null` and `undefined`) call String constructor
> ```javascript
> new Element("static").toString() // 1,2,3
> ```
> Therefore, we can say the Getter wrapper is **universal** but not only for string.

## Tag function

Use tag function can help us specify the title with more flexibility, as the original way (string) reserved meanwhile. i.e.

https://github.com/ret2shell/ret2shell/blob/b53b635e111591e8fee45d7e7144f339c0eb006e/web/src/lib/storage/theme.ts#L88-L93

https://github.com/ret2shell/ret2shell/blob/b53b635e111591e8fee45d7e7144f339c0eb006e/web/src/routes/games/layout.tsx#L13

Function `tmpl` will returns `RichTitle` instance:

https://github.com/ret2shell/ret2shell/blob/b53b635e111591e8fee45d7e7144f339c0eb006e/web/src/lib/storage/header.ts#L72-L74

## Ignit title change again after API request

Note `resolveTitle(location.pathname);`:

https://github.com/ret2shell/ret2shell/blob/b53b635e111591e8fee45d7e7144f339c0eb006e/web/src/routes/layout.tsx#L417-L426

## More...

In the definition of component `Title`, support RichTitle, Raw String, Raw Dynamic Element Wrapper to pass in:

https://github.com/ret2shell/ret2shell/blob/b53b635e111591e8fee45d7e7144f339c0eb006e/web/src/lib/storage/header.ts#L128

https://github.com/ret2shell/ret2shell/blob/b53b635e111591e8fee45d7e7144f339c0eb006e/web/src/routes/index.tsx#L33

`RichTitle.from` will change them all to `RichTitle` instance.

> [!NOTE]
> Though `RichTitle` declares `args` as `(string | DynamicElement)[]`, but it exactly supports `any[]`
> https://github.com/ret2shell/ret2shell/blob/b53b635e111591e8fee45d7e7144f339c0eb006e/web/src/lib/storage/header.ts#L7-L16
> The reason is that all `toString` interface considers all the cases, as listed following.

In order to adapt to the multi-type in tag function, when processing `toString`, other types and `undefined`, `null` are also taken into consideration:

https://github.com/ret2shell/ret2shell/blob/b53b635e111591e8fee45d7e7144f339c0eb006e/web/src/lib/storage/header.ts#L55

https://github.com/ret2shell/ret2shell/blob/b53b635e111591e8fee45d7e7144f339c0eb006e/web/src/lib/storage/header.ts#L65

https://github.com/ret2shell/ret2shell/blob/b53b635e111591e8fee45d7e7144f339c0eb006e/web/src/lib/utils/dynamic-record.ts#L21

So the class `RichTest` is **universal** but not only for string and DynamicElement. The universal depends on each implementation of `toString` interface for all parameters passing in.

---

# Other optimization

Optimize `findRoute` and `insertRoute` method for `RootHeader`. Convert the recursive algorithm into a loop.

https://github.com/ret2shell/ret2shell/blob/b53b635e111591e8fee45d7e7144f339c0eb006e/web/src/lib/storage/header.ts#L91-L123