### PR TITLE
Local cache server for actions build

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -70,6 +70,7 @@ jobs:
         cargo build --bin r2s-server --release --target '${{ matrix.target }}'
 
     - name: Upload artifact
+      continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
         name: r2s-server

--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -20,6 +20,9 @@ jobs:
         target: [x86_64-unknown-linux-musl]
     env:
       R2S_GIT_VERSION: unknown
+      # These environment variables will be set by `setup-env.sh`
+      commit_sha: unknown
+      app_v: unknown
 
     steps:
     - uses: actions/checkout@v4
@@ -40,22 +43,26 @@ jobs:
       with:
         targets: ${{ matrix.target }}
 
-    # Still looking for a stable local-cache action. considered `corca-ai/local-cache`.
-    # - name: Cache
-    #   uses: actions/cache@v4
-    #   with:
-    #     path: target/
-    #     key: rustc-${{ runner.os }}-${{ matrix.target }}-${{ steps.setup-env.outputs.cache_v }}
-    #     restore-keys: |
-    #       rustc-${{ runner.os }}-${{ matrix.target }}-
-    #       rustc-${{ runner.os }}-
+    - name: Cache cargo
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: cargo-${{ runner.os }}-${{ steps.setup-env.outputs.cache_v }}
+        restore-keys: |
+          cargo-${{ runner.os }}-
 
-    - name: Cache locally
-      id: cache
-      run: |
-        key='rustc-${{ runner.os }}-${{ matrix.target }}-${{ steps.setup-env.outputs.cache_v }}'
-        echo "cache-key=$key" >> $GITHUB_OUTPUT
-        rsync -aP --info=progress2 --exclude='**/.cargo-lock' --exclude='**/*.lock' '/home/runner/.cache/runner/'"$key"/ target/
+    - name: Cache target
+      uses: actions/cache@v4
+      with:
+        path: target/
+        key: rustc-${{ runner.os }}-${{ matrix.target }}-${{ steps.setup-env.outputs.cache_v }}
+        restore-keys: |
+          rustc-${{ runner.os }}-${{ matrix.target }}-
+          rustc-${{ runner.os }}-
 
     - name: Build on version ${{ env.app_v }}-${{ env.commit_sha }}
       run: |
@@ -66,9 +73,6 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: r2s-server
-        path: '/home/runner/.cache/runner/${{ steps.cache.outputs.cache-key }}/${{ matrix.target }}/release/r2s-server'
+        path: target/${{ matrix.target }}/release/r2s-server
         retention-days: 1
 
-    - name: Post Cache locally
-      run: |
-        rsync -aP --info=progress2 --exclude='**/.cargo-lock' --exclude='**/*.lock' target/ '/home/runner/.cache/runner/${{ steps.cache.outputs.cache-key }}'/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -90,6 +90,7 @@ jobs:
         sha256sum '${{ runner.temp }}/image.tar' > '${{ runner.temp }}/image.tar.sha256'
 
     - name: Upload artifact
+      continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.export.outputs.output_fn }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -43,6 +43,7 @@ jobs:
       run: pnpm --prefix web build
 
     - name: Upload artifact
+      continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
         name: web-dist

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -19,23 +19,25 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # - uses: pnpm/action-setup@v4
-    #   with:
-    #     version: 10
-    #     run_install: false
+    - uses: pnpm/action-setup@v4
+      with:
+        version: 10
+        run_install: false
 
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: lts/*
-        # cache: pnpm
-        # cache-dependency-path: |
-        #   web/pnpm-lock.yaml
-        #   web/package-lock.json
-        #   web/yarn.lock
+        cache: pnpm
+        cache-dependency-path: |
+          web/pnpm-lock.yaml
+          web/package-lock.json
+          web/yarn.lock
 
     - name: Install dependencies
-      run: pnpm --prefix web install
+      run: |
+        pnpm config set --global registry '${{ vars.NPM_REGISTRY }}'
+        pnpm --prefix web install
 
     - name: Build
       run: pnpm --prefix web build


### PR DESCRIPTION
Reference: https://gha-cache-server.falcondev.io/getting-started

The current version (v5 at [falcondev-oss/github-actions-cache-server@v5.0.0](https://github.com/falcondev-oss/github-actions-cache-server/tree/v5.0.0)) during this PR might affact `@actions/upload-artifacts`. Temporarily switch to V1 cache API (see https://github.com/falcondev-oss/github-actions-cache-server/issues/93). The operation for this switch is only on the self-hosted runners. We would switch to V2 if local cache server resolves the conflicts. But it's not the matter of this repository and actions fils.

The action files are universal. That means it also fit Github official runners. The only thing to do is modifying `runs-on` from `self-hosted` to others.