### PR TITLE
:bug: prevent accumlation of zombie processes

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -35,7 +35,7 @@ RUN pnpm build && \
 FROM alpine:3
 
 # hadolint ignore=DL3018
-RUN apk add --update --no-cache curl git skopeo && \
+RUN apk add --update --no-cache curl git skopeo tini && \
     git config --global user.email platform@ret.sh.cn && \
     git config --global user.name Ret2Shell
 
@@ -51,4 +51,4 @@ RUN mkdir -p \
 HEALTHCHECK --interval=5m --timeout=3s --start-period=10s --retries=1 \
     CMD curl -fsSL http://localhost:8080/api/ping || exit 1
 
-ENTRYPOINT ["/bin/r2s-server"]
+ENTRYPOINT ["/sbin/tini", "--", "/bin/r2s-server"]

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758446476,
-        "narHash": "sha256-5rdAi7CTvM/kSs6fHe1bREIva5W3TbImsto+dxG4mBo=",
+        "lastModified": 1759070547,
+        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a1f79a1770d05af18111fbbe2a3ab2c42c0f6cd0",
+        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
         "type": "github"
       },
       "original": {
@@ -83,11 +83,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758681214,
-        "narHash": "sha256-8cW731vev6kfr58cILO2ZsjHwaPhm88dQ8Q6nTSjP9I=",
+        "lastModified": 1759286284,
+        "narHash": "sha256-JLdGGc4XDutzSD1L65Ni6Ye+oTm8kWfm0KTPMcyl7Y4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b12ed88d8d33d4f3cbc842bf29fad93bb1437299",
+        "rev": "f6f2da475176bb7cff51faae8b3fe879cd393545",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### **Problem**

I've identified an issue where running `git commit` within our application's container environment leads to the creation of dangling `[git]` processes. These processes are eventually orphaned and, upon exiting, can become zombie processes (`<defunct>`).

Over time, especially under heavy load with frequent commits, this can lead to an accumulation of zombies in the process table. While individual zombies are small, a large number can consume kernel resources and make process management and debugging difficult.

### **Root Cause Analysis**

This issue is the result of two interacting factors:

1.  **Git's Automatic Maintenance:** Modern versions of Git have an auto-maintenance feature enabled by default (`maintenance.autoUpdate=true`). When `git commit` is run, Git may automatically decide to run background maintenance. It does this by spawning a `git maintenance run --auto --detach` process. The `--detach` flag causes the maintenance process to be forked and immediately orphaned by the parent `git commit` process.

2.  **The "PID 1" Problem in Containers:** By default, our application runs as Process ID (PID) 1 inside the container. On Linux, PID 1 has the special responsibility of "reaping" orphaned child processes after they exit. However, our application is not designed to function as an `init` system and does not perform this reaping.

The sequence is as follows:
*   Our app (PID 1) runs `git commit` (e.g., PID 50).
*   `git commit` forks a detached `git maintenance` process (e.g., PID 51) and then exits.
*   The `git maintenance` process is orphaned and adopted by our app (PID 1).
*   When `git maintenance` finishes and exits signaling SIGCHLD, our app (PID 1) fails to reap it, leaving a zombie process behind.