### PR TITLE
:bug: use nats double-ack to prevent redelivry

### DIFF
--- a/crates/email/src/worker.rs
+++ b/crates/email/src/worker.rs
@@ -100,7 +100,7 @@ async fn process_message(message: jetstream::Message) -> Result<(), EmailError> 
     );
   }
   message
-    .ack()
+    .double_ack()
     .await
     .inspect_err(|e| error!(error=?e, "failed to drop NATS email message"))
     .ok();

--- a/crates/event/src/worker.rs
+++ b/crates/event/src/worker.rs
@@ -14,7 +14,7 @@ pub async fn event_pusher(mut messages: Stream, manager: EventManager) {
         if let Err(error) = result {
           error!(?error, "failed to process event message");
         }
-        message.ack().await.ok();
+        message.double_ack().await.ok();
       } else {
         error!(?message, "failed to receive event message from nats");
       }

--- a/crates/server/src/middleware/forwarded.rs
+++ b/crates/server/src/middleware/forwarded.rs
@@ -359,7 +359,7 @@ async fn ip_record_worker_exec(message: jetstream::Message, db: &Database) -> an
 pub async fn ip_record_worker(mut messages: Stream, db: Database) {
   while let Some(message) = messages.next().await {
     if let Ok(message) = message {
-      message.ack().await.ok();
+      message.double_ack().await.ok();
       ip_record_worker_exec(message.clone(), &db)
         .await
         .map_err(|e| error!(error = ?e, "failed to process message"))

--- a/crates/server/src/routes/game/worker.rs
+++ b/crates/server/src/routes/game/worker.rs
@@ -57,7 +57,7 @@ async fn score_maintenance_worker(queue: Queue, db: Database) {
         })
         .ok();
       if req.is_none() {
-        message.ack().await.ok();
+        message.double_ack().await.ok();
         continue;
       }
       let challenge = serde_json::from_str::<TracedMessage<challenge::Model>>(&req.unwrap())
@@ -68,7 +68,7 @@ async fn score_maintenance_worker(queue: Queue, db: Database) {
       let span = error_span!("request", trace=%challenge.as_ref().map(|c| &c.trace).unwrap_or(&"UNKNOWN".to_owned()));
       let challenge = challenge.map(|c| c.payload);
       if challenge.is_none() {
-        message.ack().await.ok();
+        message.double_ack().await.ok();
         continue;
       }
       let challenge = challenge.unwrap();
@@ -77,7 +77,7 @@ async fn score_maintenance_worker(queue: Queue, db: Database) {
         .await
         .inspect_err(|e| error!(error=?e, "failed to process message"))
         .ok();
-      message.ack().await.ok();
+      message.double_ack().await.ok();
     }
   }
 }
@@ -154,7 +154,7 @@ async fn submission_worker(
         })
         .ok();
       if req.is_none() {
-        message.ack().await.ok();
+        message.double_ack().await.ok();
         continue;
       }
       let submission = serde_json::from_str::<TracedMessage<submission::Model>>(&req.unwrap())
@@ -163,7 +163,7 @@ async fn submission_worker(
         })
         .ok();
       if submission.is_none() {
-        message.ack().await.ok();
+        message.double_ack().await.ok();
         continue;
       }
       let trace = submission.as_ref().unwrap().trace.to_owned();
@@ -207,10 +207,10 @@ async fn submission_worker(
         )
         .await
         .ok();
-        message.ack().await.ok();
+        message.double_ack().await.ok();
         continue;
       }
-      message.ack().await.ok();
+      message.double_ack().await.ok();
     } else {
       error!(error=?message, "failed to receive message from nats");
     }


### PR DESCRIPTION
ref: https://github.com/nats-io/nats.docs/blob/master/nats-concepts/jetstream/README.md#exactly-once-semantics