### PR TITLE
:sparkles: introduce registrar scripts for intercepting registration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,6 +27,7 @@
     },
     "i18n-ally.localesPaths": ["web/src/lib/i18n"],
     "i18n-ally.keystyle": "nested",
+    "rust-analyzer.check.command": "clippy",
     "[rust]": {
         "editor.defaultFormatter": "rust-lang.rust-analyzer"
     },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4166,6 +4166,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "r2s-registrar"
+version = "3.9.0"
+dependencies = [
+ "anyhow",
+ "once_cell",
+ "r2s-engine",
+ "rune",
+ "rune-modules",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "r2s-server"
 version = "3.9.0"
 dependencies = [
@@ -4204,6 +4218,7 @@ dependencies = [
  "r2s-migrator",
  "r2s-oauth",
  "r2s-queue",
+ "r2s-registrar",
  "rand 0.9.2",
  "regex",
  "rustc_version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,22 +73,23 @@ tracing-core       = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 urlencoding        = "2.1"
 
-r2s-auditor  = { version = "3", path = "crates/auditor" }
-r2s-bucket   = { version = "3", path = "crates/bucket" }
-r2s-cache    = { version = "3", path = "crates/cache" }
-r2s-captcha  = { version = "3", path = "crates/captcha" }
-r2s-checker  = { version = "3", path = "crates/checker" }
-r2s-cluster  = { version = "3", path = "crates/cluster" }
-r2s-config   = { version = "3", path = "crates/config" }
-r2s-database = { version = "3", path = "crates/database" }
-r2s-email    = { version = "3", path = "crates/email" }
-r2s-engine   = { version = "3", path = "crates/engine" }
-r2s-event    = { version = "3", path = "crates/event" }
-r2s-license  = { version = "3", path = "crates/license" }
-r2s-media    = { version = "3", path = "crates/media" }
-r2s-migrator = { version = "3", path = "crates/migrator" }
-r2s-oauth    = { version = "3", path = "crates/oauth" }
-r2s-queue    = { version = "3", path = "crates/queue" }
+r2s-auditor   = { version = "3", path = "crates/auditor" }
+r2s-bucket    = { version = "3", path = "crates/bucket" }
+r2s-cache     = { version = "3", path = "crates/cache" }
+r2s-captcha   = { version = "3", path = "crates/captcha" }
+r2s-checker   = { version = "3", path = "crates/checker" }
+r2s-cluster   = { version = "3", path = "crates/cluster" }
+r2s-config    = { version = "3", path = "crates/config" }
+r2s-database  = { version = "3", path = "crates/database" }
+r2s-email     = { version = "3", path = "crates/email" }
+r2s-engine    = { version = "3", path = "crates/engine" }
+r2s-event     = { version = "3", path = "crates/event" }
+r2s-license   = { version = "3", path = "crates/license" }
+r2s-media     = { version = "3", path = "crates/media" }
+r2s-migrator  = { version = "3", path = "crates/migrator" }
+r2s-oauth     = { version = "3", path = "crates/oauth" }
+r2s-queue     = { version = "3", path = "crates/queue" }
+r2s-registrar = { version = "3", path = "crates/registrar" }
 
 [workspace.dependencies.axum]
 features = ["ws", "http2", "tower-log", "tracing", "multipart", "macros"]

--- a/crates/config/src/auth.rs
+++ b/crates/config/src/auth.rs
@@ -39,6 +39,12 @@ impl Merge for Option<Config> {
   fn merge(self, other: Self) -> Self {
     // prefers fields in `other`
     match (self, other) {
+      (Some(a), Some(b)) => Some(Config {
+        signing_key: a.signing_key,
+        buffer_time: a.buffer_time,
+        expires_time: a.expires_time,
+        registrar_script: b.registrar_script.or(a.registrar_script),
+      }),
       (Some(a), _) => Some(a),
       (None, Some(b)) => Some(b),
       (None, None) => None,

--- a/crates/config/src/auth.rs
+++ b/crates/config/src/auth.rs
@@ -23,6 +23,7 @@ pub struct Config {
   pub signing_key: String,
   pub buffer_time: i64,
   pub expires_time: i64,
+  pub registrar_script: Option<String>,
 }
 
 impl Config {

--- a/crates/email/src/traits.rs
+++ b/crates/email/src/traits.rs
@@ -31,3 +31,16 @@ pub enum EmailError {
   #[error("address error: {0}")]
   AddressError(#[from] lettre::address::AddressError),
 }
+
+impl EmailError {
+  pub fn can_retry(&self) -> bool {
+    match self {
+      EmailError::MailerError(error) => !error.is_permanent(),
+      EmailError::InvalidEmailTlsConfiguration(_) => false,
+      EmailError::SerdeError(_) => false,
+      EmailError::Utf8Error(_) => false,
+      EmailError::LettreError(error) => matches!(error, lettre::error::Error::Io(_)),
+      EmailError::AddressError(_) => false,
+    }
+  }
+}

--- a/crates/email/src/worker.rs
+++ b/crates/email/src/worker.rs
@@ -75,21 +75,34 @@ async fn process_message(message: jetstream::Message) -> Result<(), EmailError> 
   let req = req.payload;
   let mut retry_count = 3;
   while retry_count > 0 {
-    if let Err(err) = send_email_impl(&req.config, &req.email).await {
-      warn!(
-        email = %req.email.email,
-        subject = %req.email.subject,
-        error = ?err,
-        "failed to send email, retrying...",
-      );
-      retry_count -= 1;
-    } else {
-      info!(
-        email = %req.email.email,
-        subject = %req.email.subject,
-        "successfully sent email",
-      );
-      break;
+    match send_email_impl(&req.config, &req.email).await {
+      Ok(_) => {
+        info!(
+          email = %req.email.email,
+          subject = %req.email.subject,
+          "successfully sent email",
+        );
+        break;
+      }
+      Err(error) if !error.can_retry() => {
+        error!(
+          email = %req.email.email,
+          subject = %req.email.subject,
+          error = ?error,
+          "failed to send email, permanent error, dropped.",
+        );
+        break;
+      }
+      Err(error) => {
+        warn!(
+          email = %req.email.email,
+          subject = %req.email.subject,
+          error = ?error,
+          "failed to send email, retrying...",
+        );
+        retry_count -= 1;
+        continue;
+      }
     }
   }
   if retry_count < 0 {

--- a/crates/registrar/Cargo.toml
+++ b/crates/registrar/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+description = "Registration interception via Rune scripts for Ret2Shell"
+name        = "r2s-registrar"
+
+authors      = { workspace = true }
+edition      = { workspace = true }
+homepage     = { workspace = true }
+publish      = { workspace = true }
+repository   = { workspace = true }
+rust-version = { workspace = true }
+version      = { workspace = true }
+
+[dependencies]
+anyhow       = { workspace = true }
+once_cell    = { workspace = true }
+rune         = { workspace = true }
+rune-modules = { workspace = true }
+serde        = { workspace = true }
+serde_json   = { workspace = true }
+thiserror    = { workspace = true }
+
+r2s-engine = { workspace = true }
+
+[lib]
+path = "src/lib.rs"

--- a/crates/registrar/src/lib.rs
+++ b/crates/registrar/src/lib.rs
@@ -6,8 +6,11 @@ use thiserror::Error;
 #[derive(Clone, Debug, Any)]
 #[rune(item = ::ret2shell::registrar)]
 pub struct RegisterInfo {
+  #[rune(get)]
   pub account: String,
+  #[rune(get)]
   pub nickname: String,
+  #[rune(get)]
   pub email: String,
 }
 
@@ -71,8 +74,10 @@ impl Registrar {
     let result = GLOBAL_ENGINE
       .execute(key, "intercept", (info.clone(),))
       .await?;
-    // Expect either an object with fields or a string error
-    if let Ok(object) = rune::from_value::<Object>(result.clone()) {
+    // Expect Result<Object, Value>
+    let output: Result<Object, rune::Value> =
+      rune::from_value(result).map_err(EngineError::from)?;
+    if let Ok(object) = output {
       let mut resp = RegisterResult::default();
       for (k, v) in object.iter() {
         match k.as_str() {
@@ -89,12 +94,19 @@ impl Registrar {
         }
       }
       Ok(resp)
-    } else if let Ok(reason) = rune::from_value::<String>(result) {
-      Err(RegistrarError::Rejected(reason))
     } else {
-      Err(RegistrarError::Rejected(
-        "invalid registrar result".to_owned(),
-      ))
+      // Err branch: string reason or printable value
+      if let Some(Ok(reason)) = output.err().map(|v| rune::from_value::<String>(v.clone())) {
+        Err(RegistrarError::Rejected(reason))
+      } else {
+        Err(RegistrarError::Rejected("rejected".to_owned()))
+      }
     }
+  }
+
+  pub async fn expire(&self, key: impl AsRef<str>) {
+    GLOBAL_ENGINE
+      .expire(format!("registrar-{}", key.as_ref()))
+      .await;
   }
 }

--- a/crates/registrar/src/lib.rs
+++ b/crates/registrar/src/lib.rs
@@ -1,0 +1,100 @@
+use r2s_engine::{DiagnosticMarker, Engine, EngineError, GLOBAL_ENGINE};
+use rune::{Any, ContextError, Module, runtime::Object};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Clone, Debug, Any)]
+#[rune(item = ::ret2shell::registrar)]
+pub struct RegisterInfo {
+  pub account: String,
+  pub nickname: String,
+  pub email: String,
+}
+
+#[derive(Clone, Debug, Default, Any, Serialize, Deserialize)]
+#[rune(item = ::ret2shell::registrar)]
+pub struct RegisterResult {
+  /// When true, skip sending verification email and mark verified
+  pub bypass_email_verification: bool,
+  /// Optionally assign an institute id directly
+  pub institute_id: Option<i64>,
+  /// Or join institute by token
+  pub institute_token: Option<String>,
+}
+
+#[derive(Error, Debug, Any)]
+#[rune(item = ::ret2shell::registrar)]
+pub enum RegistrarError {
+  #[error("rejected: {0}")]
+  Rejected(String),
+  #[error("engine error: {0}")]
+  EngineError(#[from] EngineError),
+}
+
+#[rune::module(::ret2shell::registrar)]
+pub fn module(_stdio: bool) -> Result<Module, ContextError> {
+  let mut module = Module::from_meta(self::module_meta)?;
+  module.ty::<RegisterInfo>()?;
+  module.ty::<RegisterResult>()?;
+  Ok(module)
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Registrar;
+
+impl Registrar {
+  fn default_modules() -> Vec<fn(bool) -> Result<rune::Module, rune::ContextError>> {
+    vec![
+      rune_modules::json::module,
+      rune_modules::toml::module,
+      module,
+    ]
+  }
+
+  pub async fn lint(&self, script: impl AsRef<str>) -> Result<Vec<DiagnosticMarker>, EngineError> {
+    Engine::lint(Self::default_modules(), script, &["intercept"]).await
+  }
+
+  pub async fn preload(
+    &self, key: impl AsRef<str>, script: impl AsRef<str>,
+  ) -> Result<(), EngineError> {
+    let key = format!("registrar-{}", key.as_ref());
+    GLOBAL_ENGINE
+      .preload(Self::default_modules(), key, script, None)
+      .await
+  }
+
+  pub async fn intercept(
+    &self, key: impl AsRef<str>, info: &RegisterInfo,
+  ) -> Result<RegisterResult, RegistrarError> {
+    let key = format!("registrar-{}", key.as_ref());
+    let result = GLOBAL_ENGINE
+      .execute(key, "intercept", (info.clone(),))
+      .await?;
+    // Expect either an object with fields or a string error
+    if let Ok(object) = rune::from_value::<Object>(result.clone()) {
+      let mut resp = RegisterResult::default();
+      for (k, v) in object.iter() {
+        match k.as_str() {
+          "bypass_email_verification" => {
+            resp.bypass_email_verification = rune::from_value(v.clone()).unwrap_or(false);
+          }
+          "institute_id" => {
+            resp.institute_id = rune::from_value(v.clone()).ok();
+          }
+          "institute_token" => {
+            resp.institute_token = rune::from_value(v.clone()).ok();
+          }
+          _ => {}
+        }
+      }
+      Ok(resp)
+    } else if let Ok(reason) = rune::from_value::<String>(result) {
+      Err(RegistrarError::Rejected(reason))
+    } else {
+      Err(RegistrarError::Rejected(
+        "invalid registrar result".to_owned(),
+      ))
+    }
+  }
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -49,22 +49,23 @@ tracing-appender   = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 # local crates
-r2s-auditor  = { workspace = true }
-r2s-bucket   = { workspace = true }
-r2s-cache    = { workspace = true }
-r2s-captcha  = { workspace = true }
-r2s-checker  = { workspace = true }
-r2s-cluster  = { workspace = true }
-r2s-config   = { workspace = true }
-r2s-database = { workspace = true }
-r2s-email    = { workspace = true }
-r2s-engine   = { workspace = true }
-r2s-event    = { workspace = true }
-r2s-license  = { workspace = true }
-r2s-media    = { workspace = true }
-r2s-migrator = { workspace = true }
-r2s-oauth    = { workspace = true }
-r2s-queue    = { workspace = true }
+r2s-auditor   = { workspace = true }
+r2s-bucket    = { workspace = true }
+r2s-cache     = { workspace = true }
+r2s-captcha   = { workspace = true }
+r2s-checker   = { workspace = true }
+r2s-cluster   = { workspace = true }
+r2s-config    = { workspace = true }
+r2s-database  = { workspace = true }
+r2s-email     = { workspace = true }
+r2s-engine    = { workspace = true }
+r2s-event     = { workspace = true }
+r2s-license   = { workspace = true }
+r2s-media     = { workspace = true }
+r2s-migrator  = { workspace = true }
+r2s-oauth     = { workspace = true }
+r2s-queue     = { workspace = true }
+r2s-registrar = { workspace = true }
 
 [build-dependencies]
 build-target  = { workspace = true }

--- a/crates/server/src/routes/account/mod.rs
+++ b/crates/server/src/routes/account/mod.rs
@@ -494,7 +494,6 @@ async fn register(
 
   let permissions =
     crate::utility::registrar::compute_permissions(&txn, &config, &registrar_result).await?;
-  let email = body.email.clone();
   // Resolve institute assignment from registrar_result
   let assigned_institute_id =
     crate::utility::registrar::resolve_institute(&txn, None, &registrar_result).await?;
@@ -502,7 +501,7 @@ async fn register(
     account: body.account.clone(),
     nickname: body.nickname.clone(),
     password: Some(password),
-    email: Some(body.email),
+    email: Some(body.email.clone()),
     registered_at: Utc::now(),
     permissions,
     hidden: false,
@@ -522,7 +521,7 @@ async fn register(
       queue,
       &config,
       &user.account,
-      &email,
+      &body.email,
       EmailType::Verify,
       &trace.header_value().to_str().unwrap_or("UNKNOWN"),
     )

--- a/crates/server/src/routes/account/mod.rs
+++ b/crates/server/src/routes/account/mod.rs
@@ -17,6 +17,7 @@ use r2s_database::{
 use r2s_email::{EmailCtx, EmailRequest};
 use r2s_migrator::Database;
 use r2s_queue::Queue;
+use r2s_registrar::RegisterInfo;
 use rand::Rng;
 use sea_orm::TransactionTrait;
 use serde::{Deserialize, Serialize};
@@ -483,25 +484,20 @@ async fn register(
 
   let password = hash_password(&body.password)?;
 
-  let mut permissions = match user::count(&txn, true, None, None, false).await? {
-    0 => Permissions(vec![
-      Permission::Basic,
-      Permission::Verified,
-      Permission::Calendar,
-      Permission::Wiki,
-      Permission::Bulletin,
-      Permission::Game,
-      Permission::Host,
-      Permission::User,
-      Permission::Statistics,
-      Permission::DevOps,
-    ]),
-    _ => Permissions(vec![Permission::Basic]),
+  // Registrar interception
+  let info = RegisterInfo {
+    account: body.account.clone(),
+    nickname: body.nickname.clone(),
+    email: body.email.clone(),
   };
-  if !config.email.as_ref().is_some_and(|c| c.enabled) && permissions.0.len() == 1 {
-    permissions.0.push(Permission::Verified);
-  }
+  let registrar_result = crate::utility::registrar::intercept(&config.auth, &info).await?;
+
+  let permissions =
+    crate::utility::registrar::compute_permissions(&txn, &config, &registrar_result).await?;
   let email = body.email.clone();
+  // Resolve institute assignment from registrar_result
+  let assigned_institute_id =
+    crate::utility::registrar::resolve_institute(&txn, None, &registrar_result).await?;
   let new_user = user::Model {
     account: body.account.clone(),
     nickname: body.nickname.clone(),
@@ -511,6 +507,7 @@ async fn register(
     permissions,
     hidden: false,
     banned: false,
+    institute_id: assigned_institute_id,
     ..Default::default()
   };
 
@@ -518,17 +515,20 @@ async fn register(
 
   txn.commit().await?;
 
-  send_email(
-    &cache,
-    queue,
-    &config,
-    &user.account,
-    &email,
-    EmailType::Verify,
-    &trace.header_value().to_str().unwrap_or("UNKNOWN"),
-  )
-  .await
-  .ok();
+  // send verification email only when not already verified
+  if !user.permissions.0.contains(&Permission::Verified) {
+    send_email(
+      &cache,
+      queue,
+      &config,
+      &user.account,
+      &email,
+      EmailType::Verify,
+      &trace.header_value().to_str().unwrap_or("UNKNOWN"),
+    )
+    .await
+    .ok();
+  }
   info!(
     id=%user.id,
     account=%user.account,

--- a/crates/server/src/routes/account/oauth.rs
+++ b/crates/server/src/routes/account/oauth.rs
@@ -13,11 +13,12 @@ use r2s_cache::Cache;
 use r2s_config::captcha::ValidatorType;
 use r2s_database::{
   config,
-  user::{self, Permission, Permissions},
+  user::{self, Permission},
 };
 use r2s_migrator::Database;
 use r2s_oauth::OAuth;
 use r2s_queue::Queue;
+use r2s_registrar::RegisterInfo;
 use sea_orm::TransactionTrait;
 use serde::{Deserialize, Serialize};
 use tower_http::request_id::RequestId;
@@ -290,36 +291,32 @@ async fn register_with_oauth_account(
 
   let password = hash_password(&req.password)?;
 
-  let mut permissions = match user::count(&txn, true, None, None, false).await? {
-    0 => Permissions(vec![
-      Permission::Basic,
-      Permission::Verified,
-      Permission::Calendar,
-      Permission::Wiki,
-      Permission::Bulletin,
-      Permission::Game,
-      Permission::Host,
-      Permission::User,
-      Permission::Statistics,
-      Permission::DevOps,
-    ]),
-    _ => Permissions(vec![Permission::Basic]),
+  // Registrar interception
+  let info = RegisterInfo {
+    account: req.account.clone(),
+    nickname: req.nickname.clone(),
+    email: req.email.clone(),
   };
-  if !config.email.as_ref().is_some_and(|c| c.enabled) && permissions.0.len() == 1 {
-    permissions.0.push(Permission::Verified);
-  }
-  let email = req.email.clone();
+  let registrar_result = crate::utility::registrar::intercept(&config.auth, &info).await?;
+  let permissions =
+    crate::utility::registrar::compute_permissions(&txn, &config, &registrar_result).await?;
   let institute = r2s_database::institute::get_by_provider(&txn, &cached_token.provider).await?;
+  let institute_id = crate::utility::registrar::resolve_institute(
+    &txn,
+    institute.clone().map(|i| i.id),
+    &registrar_result,
+  )
+  .await?;
   let new_user = user::Model {
     account: req.account.clone(),
     nickname: req.nickname.clone(),
     password: Some(password),
-    email: Some(req.email),
+    email: Some(req.email.clone()),
     registered_at: Utc::now(),
     permissions,
     hidden: false,
     banned: false,
-    institute_id: institute.clone().map(|i| i.id),
+    institute_id,
     ..Default::default()
   };
   let user = user::create(&txn, new_user).await?;
@@ -337,17 +334,19 @@ async fn register_with_oauth_account(
 
   txn.commit().await?;
 
-  send_email(
-    &cache,
-    &queue,
-    &config,
-    &user.account,
-    &email,
-    EmailType::Verify,
-    &trace.header_value().to_str().unwrap_or("UNKNOWN"),
-  )
-  .await
-  .ok();
+  if !user.permissions.0.contains(&Permission::Verified) {
+    send_email(
+      &cache,
+      &queue,
+      &config,
+      &user.account,
+      &req.email,
+      EmailType::Verify,
+      &trace.header_value().to_str().unwrap_or("UNKNOWN"),
+    )
+    .await
+    .ok();
+  }
   info!(
     provider=%cached_token.provider,
     id = user.id,
@@ -415,8 +414,7 @@ async fn bind_oauth_account(
         ("email", user.email.clone().unwrap_or_default()),
       ]
       .iter()
-      .cloned()
-      .map(|(k, v)| (k.to_owned(), v.to_owned()))
+      .map(|(k, v)| (k.to_string(), v.to_string()))
       .collect(),
     )
     .await?;

--- a/crates/server/src/routes/platform/mod.rs
+++ b/crates/server/src/routes/platform/mod.rs
@@ -5,7 +5,7 @@ use axum::{
   extract::{Query, State},
   middleware,
   response::{IntoResponse, Response},
-  routing::get,
+  routing::{get, patch},
 };
 use chrono::{DateTime, Utc};
 use futures::future::join_all;
@@ -35,6 +35,10 @@ pub fn router(_state: &GlobalState) -> Router<GlobalState> {
     .merge(
       Router::new()
         .route("/config", get(get_config).patch(update_config))
+        .route(
+          "/registrar",
+          patch(update_registrar_script).delete(delete_registrar_script),
+        )
         .route_layer(middleware::from_fn(auth::permission_required_all!(
           Permission::DevOps
         ))),
@@ -67,6 +71,68 @@ async fn update_config(
   let result = config::update(&db.conn, config).await?;
   cache.at("platform").del("config").await?;
   Ok(Json(result))
+}
+
+#[derive(Serialize)]
+struct RegistrarScriptResponse {
+  pub lint: Vec<r2s_engine::DiagnosticMarker>,
+}
+
+#[derive(Deserialize)]
+struct RegistrarScriptRequest {
+  registrar: String,
+}
+
+async fn update_registrar_script(
+  State(ref db): State<Database>, State(ref cache): State<Cache>,
+  Extension(config): Extension<config::Model>, Json(req): Json<RegistrarScriptRequest>,
+) -> Result<impl IntoResponse, ResponseError> {
+  let registrar = r2s_registrar::Registrar;
+  let lint = registrar.lint(&req.registrar).await?;
+  let _ = r2s_database::config::update(
+    &db.conn,
+    r2s_database::config::Model {
+      auth: Some(r2s_config::auth::Config {
+        registrar_script: Some(req.registrar.clone()),
+        ..config.auth.unwrap_or(r2s_config::auth::Config {
+          signing_key: String::new(),
+          buffer_time: 21600,
+          expires_time: 86400,
+          registrar_script: None,
+        })
+      }),
+      ..config
+    },
+  )
+  .await?;
+  registrar.expire("default").await;
+  cache.at("platform").del("config").await?;
+  Ok(Json(RegistrarScriptResponse { lint }))
+}
+
+async fn delete_registrar_script(
+  State(ref db): State<Database>, State(ref cache): State<Cache>,
+  Extension(config): Extension<config::Model>,
+) -> Result<impl IntoResponse, ResponseError> {
+  let _ = r2s_database::config::update(
+    &db.conn,
+    r2s_database::config::Model {
+      auth: Some(r2s_config::auth::Config {
+        registrar_script: None,
+        ..config.auth.unwrap_or(r2s_config::auth::Config {
+          signing_key: String::new(),
+          buffer_time: 21600,
+          expires_time: 86400,
+          registrar_script: None,
+        })
+      }),
+      ..config
+    },
+  )
+  .await?;
+  r2s_registrar::Registrar.expire("default").await;
+  cache.at("platform").del("config").await?;
+  Ok(())
 }
 
 async fn get_platform_info(

--- a/crates/server/src/utility/mod.rs
+++ b/crates/server/src/utility/mod.rs
@@ -1,3 +1,4 @@
 pub mod file;
 pub mod password;
+pub mod registrar;
 pub mod string;

--- a/crates/server/src/utility/registrar.rs
+++ b/crates/server/src/utility/registrar.rs
@@ -1,0 +1,87 @@
+use r2s_config as config;
+use r2s_database::user::{self, Permission, Permissions};
+use r2s_registrar::{RegisterInfo, RegisterResult, Registrar};
+use sea_orm::ConnectionTrait;
+
+use crate::traits::ResponseError;
+
+pub async fn intercept(
+  auth_config: &Option<config::auth::Config>, info: &RegisterInfo,
+) -> Result<Option<RegisterResult>, ResponseError> {
+  if let Some(script) = auth_config.clone().and_then(|a| a.registrar_script) {
+    let registrar = Registrar;
+    registrar.preload("default", &script).await?;
+    match registrar.intercept("default", info).await {
+      Ok(result) => Ok(Some(result)),
+      Err(r2s_registrar::RegistrarError::Rejected(msg)) => Err(ResponseError::Forbidden(msg)),
+      Err(err) => {
+        tracing::error!(error=?err, "registrar error");
+        Err(ResponseError::InternalServerError(
+          "registrar failed".to_owned(),
+        ))
+      }
+    }
+  } else {
+    Ok(None)
+  }
+}
+
+pub async fn compute_permissions<C>(
+  db: &C, cfg: &r2s_database::config::Model, registrar_result: &Option<RegisterResult>,
+) -> Result<Permissions, ResponseError>
+where
+  C: ConnectionTrait, {
+  let mut permissions = match user::count(db, true, None, None, false).await? {
+    0 => Permissions(vec![
+      Permission::Basic,
+      Permission::Verified,
+      Permission::Calendar,
+      Permission::Wiki,
+      Permission::Bulletin,
+      Permission::Game,
+      Permission::Host,
+      Permission::User,
+      Permission::Statistics,
+      Permission::DevOps,
+    ]),
+    _ => Permissions(vec![Permission::Basic]),
+  };
+  if (cfg.email.as_ref().is_some_and(|c| !c.enabled) // if email is disabled
+    || (registrar_result // if registrar script explicitly bypass email verification
+      .as_ref()
+      .is_some_and(|r| r.bypass_email_verification)))
+    && permissions.0.len() == 1
+  // if permissions only contains basic
+  {
+    permissions.0.push(Permission::Verified);
+  }
+  Ok(permissions)
+}
+
+pub async fn resolve_institute<C>(
+  db: &C, default_institute: Option<i64>, registrar_result: &Option<RegisterResult>,
+) -> Result<Option<i64>, ResponseError>
+where
+  C: ConnectionTrait, {
+  let mut institute_id = default_institute;
+  if let Some(id) = registrar_result.as_ref().and_then(|r| r.institute_id) {
+    if r2s_database::institute::get(db, id).await?.is_some() {
+      institute_id = Some(id);
+    } else {
+      return Err(ResponseError::BadRequest("invalid institute id".to_owned()));
+    }
+  } else if let Some(token) = registrar_result
+    .as_ref()
+    .and_then(|r| r.institute_token.as_ref())
+  {
+    let i = r2s_database::institute::get_by_token(db, token).await?;
+    if let Some(i) = i {
+      institute_id = Some(i.id);
+    } else {
+      return Err(ResponseError::BadRequest(
+        "invalid institute token".to_owned(),
+      ));
+    }
+  }
+  Ok(institute_id)
+}

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759070547,
-        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
+        "lastModified": 1759417375,
+        "narHash": "sha256-O7eHcgkQXJNygY6AypkF9tFhsoDQjpNEojw3eFs73Ow=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
+        "rev": "dc704e6102e76aad573f63b74c742cd96f8f1e6c",
         "type": "github"
       },
       "original": {
@@ -83,11 +83,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759286284,
-        "narHash": "sha256-JLdGGc4XDutzSD1L65Ni6Ye+oTm8kWfm0KTPMcyl7Y4=",
+        "lastModified": 1759458749,
+        "narHash": "sha256-WKnbJnm1B2+TO2ZUudgS39EzecQeLl4/bnRtd3y46LI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f6f2da475176bb7cff51faae8b3fe879cd393545",
+        "rev": "bbc3a8ae797d1700e57a4f4bcc4e79af727d4138",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -39,9 +39,7 @@
         system:
         let
           pkgs = pkgsBySystem.${system};
-          rust = pkgs.rust-bin.stable.latest.default.override {
-            extensions = [ "rust-src" ];
-          };
+          rust = pkgs.rust-bin.nightly.latest.complete;
         in
         {
           default = pkgs.mkShell {

--- a/web/src/lib/api/platform.ts
+++ b/web/src/lib/api/platform.ts
@@ -100,3 +100,13 @@ export async function getPlatformConfig() {
 export async function updatePlatformConfig(config: Config) {
   return await api.patch(`${api_root}/platform/config`, { json: config }).json<Config>();
 }
+
+export async function updateRegistrarScript(registrar: string) {
+  return await api
+    .patch(`${api_root}/platform/registrar`, { json: { registrar } })
+    .json<{ lint: import("@widgets/editor").DiagnosticMarker[] }>();
+}
+
+export async function deleteRegistrarScript() {
+  return await api.delete(`${api_root}/platform/registrar`).json<void>();
+}

--- a/web/src/lib/i18n/en-us.json
+++ b/web/src/lib/i18n/en-us.json
@@ -2064,6 +2064,15 @@
       "multiNodeDirectScript": "Multi-node direct connection"
     }
   },
+  "registrar": {
+    "title": "Registrar",
+    "script": "Registration script",
+    "preset": {
+      "title": "Script presets",
+      "limitSuffix": "Limit email suffix",
+      "inviteBySuffix": "Invite by email suffix"
+    }
+  },
   "cluster": {
     "title": "Cluster management",
     "status": {

--- a/web/src/lib/i18n/ja-jp.json
+++ b/web/src/lib/i18n/ja-jp.json
@@ -2064,6 +2064,15 @@
       "multiNodeDirectScript": "マルチノード直結"
     }
   },
+  "registrar": {
+    "title": "レジストラ",
+    "script": "登録スクリプト",
+    "preset": {
+      "title": "スクリプトプリセット",
+      "limitSuffix": "メールのサフィックスを制限",
+      "inviteBySuffix": "メールのサフィックスで所属に自動招待"
+    }
+  },
   "cluster": {
     "title": "クラスタ管理",
     "status": {

--- a/web/src/lib/i18n/zh-cn.json
+++ b/web/src/lib/i18n/zh-cn.json
@@ -2064,6 +2064,15 @@
       "multiNodeDirectScript": "多节点直连"
     }
   },
+  "registrar": {
+    "title": "注册拦截",
+    "script": "注册脚本",
+    "preset": {
+      "title": "脚本预设",
+      "limitSuffix": "限制邮箱后缀",
+      "inviteBySuffix": "按邮箱后缀自动邀请入组织"
+    }
+  },
   "cluster": {
     "title": "集群管理",
     "status": {

--- a/web/src/lib/i18n/zh-tw.json
+++ b/web/src/lib/i18n/zh-tw.json
@@ -2064,6 +2064,15 @@
       "multiNodeDirectScript": "多節點直連"
     }
   },
+  "registrar": {
+    "title": "註冊攔截",
+    "script": "註冊腳本",
+    "preset": {
+      "title": "腳本預設",
+      "limitSuffix": "限制信箱後綴",
+      "inviteBySuffix": "依信箱後綴自動邀請入組織"
+    }
+  },
   "cluster": {
     "title": "集群管理",
     "status": {

--- a/web/src/lib/models/config.ts
+++ b/web/src/lib/models/config.ts
@@ -9,6 +9,7 @@ export type AuthConfig = {
   signing_key: string;
   buffer_time: number;
   expires_time: number;
+  registrar_script?: string | null;
 };
 export type AutomateConfig = {
   enabled: boolean;
@@ -40,6 +41,7 @@ export type ClusterConfig = {
   node_selector: string | null;
   proxy_image: string | null;
   traffic: string | null;
+  // legacy fields supported by backend
   enable_capture: boolean | null;
   capture_directory: string | null;
   registry: RegistryConfig | null;

--- a/web/src/routes/admin/_blocks/sidebar.tsx
+++ b/web/src/routes/admin/_blocks/sidebar.tsx
@@ -158,6 +158,19 @@ export default function SideBar() {
           <span>{t("traffic.title")}</span>
         </Link>
       </li>
+      <li class="w-full">
+        <Link
+          activeMatch="exact"
+          class="w-full"
+          ghost
+          href="/admin/registrar"
+          justify="start"
+          disabled={!accountStore.permissions.includes(Permission.DevOps)}
+        >
+          <span class="shrink-0 icon-[fluent--document-bullet-list-20-regular] w-5 h-5" />
+          <span>{t("registrar.title")}</span>
+        </Link>
+      </li>
       <Divider />
       <li class="w-full">
         <Link activeMatch="exact" class="w-full" ghost href="/magic/about" justify="start">

--- a/web/src/routes/admin/registrar/index.tsx
+++ b/web/src/routes/admin/registrar/index.tsx
@@ -1,0 +1,147 @@
+import { handleHttpError } from "@api";
+import { deleteRegistrarScript, getPlatformConfig, updateRegistrarScript } from "@api/platform";
+import { Title } from "@storage/header";
+import { t } from "@storage/theme";
+import { addToast } from "@storage/toast";
+import Button from "@widgets/button";
+import Card from "@widgets/card";
+import { type DiagnosticMarker, EditorBare } from "@widgets/editor";
+import Popover from "@widgets/popover";
+import Select from "@widgets/select";
+import { createEffect, createSignal, onMount, Show } from "solid-js";
+import inviteBySuffix from "./scripts/invite_by_suffix.rx";
+import limitSuffix from "./scripts/limit_suffix.rx";
+
+export default function Registrar() {
+  const [script, setScript] = createSignal("");
+  const [lint, setLint] = createSignal(null as DiagnosticMarker[] | null);
+  const [saving, setSaving] = createSignal(false);
+  type PresetRegistrar = "limit-email-suffix" | "invite-by-suffix";
+  const [preset, setPreset] = createSignal<PresetRegistrar | null>(null);
+  const presetScripts: Record<PresetRegistrar, string> = {
+    "limit-email-suffix": limitSuffix,
+    "invite-by-suffix": inviteBySuffix,
+  };
+
+  onMount(async () => {
+    try {
+      const cfg = await getPlatformConfig();
+      setScript(cfg.auth?.registrar_script || "");
+    } catch (err) {
+      handleHttpError(err as Error, t("platform.errors.fetchConfig.title")!);
+    }
+  });
+
+  createEffect(() => {
+    if (preset()) {
+      const key = preset()!;
+      if (presetScripts[key]) setScript(presetScripts[key]);
+    }
+  });
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      const resp = await updateRegistrarScript(script());
+      setLint(resp.lint);
+      addToast({ level: "success", description: t("general.actions.save.status.success")!, duration: 5000 });
+    } catch (err) {
+      handleHttpError(err as Error, t("general.actions.save.status.fail")!);
+    }
+    setSaving(false);
+  }
+
+  async function handleDelete() {
+    setSaving(true);
+    try {
+      await deleteRegistrarScript();
+      setScript("");
+      setLint(null);
+      addToast({ level: "success", description: t("general.actions.delete.status.success")!, duration: 5000 });
+    } catch (err) {
+      handleHttpError(err as Error, t("general.actions.delete.status.fail")!);
+    }
+    setSaving(false);
+  }
+
+  return (
+    <>
+      <Title page={t("registrar.title")!} route="/admin/registrar" />
+      <div class="flex-1 flex flex-col items-center p-3 lg:p-6 relative">
+        <div class="flex-1 flex flex-col w-full">
+          <h2 class="h-12 shrink-0 flex items-center border-b border-b-layer-content/10 font-bold space-x-2">
+            <span class="shrink-0 icon-[fluent--mail-inbox-20-regular] w-5 h-5" />
+            <span class="flex-1 flex items-center justify-start space-x-2">
+              <span>{t("registrar.script")}</span>
+              <span class="opacity-60">$GLOBAL/registrar.rx</span>
+            </span>
+            <Select
+              class="w-60 hidden lg:flex"
+              placeholder={t("registrar.preset.title")!}
+              size="sm"
+              items={[
+                {
+                  label: t("registrar.preset.limitSuffix")!,
+                  value: "limit-email-suffix",
+                  icon: "icon-[fluent--number-symbol-20-regular] w-5 h-5",
+                },
+                {
+                  label: t("registrar.preset.inviteBySuffix")!,
+                  value: "invite-by-suffix",
+                  icon: "icon-[fluent--number-symbol-20-regular] w-5 h-5",
+                },
+              ]}
+              onValueChange={(e) => setPreset((e.value.at(0) as PresetRegistrar) || null)}
+            />
+            <Button size="sm" level="primary" onClick={handleSave} loading={saving()}>
+              {t("general.actions.save.title")}
+            </Button>
+            <Show when={script().length > 0}>
+              <Popover
+                level="error"
+                ghost
+                size="sm"
+                square
+                btnContent={<span class="shrink-0 icon-[fluent--delete-20-regular] w-5 h-5" />}
+              >
+                <Card contentClass="p-2 flex flex-col space-y-2 max-w-96">
+                  <span class="inline-block space-x-2">
+                    <span class="shrink-0 icon-[fluent--warning-20-regular] w-5 h-5 text-warning align-middle" />
+                    <span>{t("general.actions.delete.message")}</span>
+                  </span>
+                  <Button level="primary" size="sm" class="self-end" onClick={handleDelete}>
+                    {t("general.actions.yes.title")}
+                  </Button>
+                </Card>
+              </Popover>
+            </Show>
+          </h2>
+          <EditorBare
+            class="w-full h-full"
+            lineNumbers
+            lang="rust"
+            value={script()}
+            lints={lint() ?? []}
+            onValueChanged={(e) => setScript(e)}
+          />
+          <footer class="min-h-12 border-t border-t-layer-content/10 flex flex-col lg:flex-row flex-wrap justify-start space-x-2 items-center gap-y-2 py-2">
+            <span class="text-primary icon-[fluent--info-16-regular]" />
+            <span class="text-primary">{lint()?.filter((v) => v.kind === "info").length ?? 0}</span>
+            <span class="text-warning icon-[fluent--warning-16-regular]" />
+            <span class="text-warning">{lint()?.filter((v) => v.kind === "warning").length ?? 0}</span>
+            <span class="text-error icon-[fluent--warning-16-regular]" />
+            <span class="text-error">{lint()?.filter((v) => v.kind === "error").length ?? 0}</span>
+            <div class="flex-1" />
+            <a href="https://rune-rs.github.io/" class="text-primary hover:underline">
+              Rune Grammar <span class="icon-[fluent--open-12-regular]" />
+            </a>
+            <span>&nbsp;&nbsp;</span>
+            <a href="https://github.com/ret2shell/ret2script" class="text-primary hover:underline">
+              Ret2Script <span class="icon-[fluent--open-12-regular]" />
+            </a>
+          </footer>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/web/src/routes/admin/registrar/scripts/invite_by_suffix.rx
+++ b/web/src/routes/admin/registrar/scripts/invite_by_suffix.rx
@@ -1,0 +1,13 @@
+//! * registrar example: invite by suffix
+
+pub async fn intercept(info) {
+  if info.email.ends_with("@faculty.edu") {
+    // Join by institute admin token
+    return Ok(#{ institute_token: "FACULTY_ADMIN_TOKEN" });
+  } else if info.email.ends_with("@student.edu") {
+    // Or assign by institute id
+    return Ok(#{ institute_id: 42 });
+  }
+  Ok(#{})
+}
+

--- a/web/src/routes/admin/registrar/scripts/limit_suffix.rx
+++ b/web/src/routes/admin/registrar/scripts/limit_suffix.rx
@@ -1,0 +1,10 @@
+//! * registrar example: limit email suffix
+
+pub async fn intercept(info) {
+  // Allow only specific email suffix
+  if !info.email.ends_with("@example.edu") {
+    return Err("Only @example.edu emails are allowed");
+  }
+  Ok(#{})
+}
+

--- a/web/src/routes/routes.ts
+++ b/web/src/routes/routes.ts
@@ -300,6 +300,10 @@ export const routes = {
           path: "/traffic",
           component: lazy(() => import("./admin/traffic/index")),
         },
+        {
+          path: "/registrar",
+          component: lazy(() => import("./admin/registrar/index")),
+        },
       ],
     },
     {


### PR DESCRIPTION
> This pull request introduces a powerful and extensible registration interception system using Rune scripts, allowing dynamic control over user registration logic. It adds a new `r2s-registrar` crate, integrates it into the backend registration flow, and exposes API endpoints for managing registration scripts. The changes also refactor registration logic to utilize this new system, enabling features like custom institute assignment and email verification bypass.

Tested features
- [x] script editing
- [x] email suffix restriction
- [ ] institution assignment
- [ ] OAuth subsystem registration compliance