### PR TITLE
:bug: avoid repeated select input dispatch for unchanged values

### DIFF
--- a/web/src/lib/widgets/select.tsx
+++ b/web/src/lib/widgets/select.tsx
@@ -84,9 +84,10 @@ export default function (
       onValueChange={(e) => {
         if (selectEl) {
           const nextValue = e.value[0] || "";
+          const prevValue = selectEl.value;
           selectEl.value = nextValue;
 
-          if (!forwardingInputEvent) {
+          if (!forwardingInputEvent && prevValue !== nextValue) {
             forwardingInputEvent = true;
             queueMicrotask(() => {
               try {


### PR DESCRIPTION
## Summary

Fixes a frontend freeze issue in the shared `Select` widget.

In the admin user edit form, changing a user's institute may cause the browser to freeze. The problem happens because `Select` can receive a new value array on each render, even when the selected value itself has not changed.

For example, `["1"]` and another newly created `["1"]` are different array references, but they represent the same selected value. The component may then repeatedly sync its internal state and dispatch hidden `select` input events, which can cause a render/event loop.

This patch:

- compares select value arrays by content before updating internal state
- dispatches the hidden `select` input event only when the actual selected value changes

## Reproduction

1. Run the web frontend against a Ret2Shell 3.10.9 backend.
2. Open Admin -> Users.
3. Edit a user.
4. Change the user's institute.
5. The browser may freeze due to repeated select input dispatch.