### PR TITLE
:sparkles: add submission records to user profile page

### DIFF
--- a/crates/database/src/entities/submission.rs
+++ b/crates/database/src/entities/submission.rs
@@ -381,10 +381,7 @@ where
   let mut sql_total = Entity::find()
     .join(JoinType::InnerJoin, Relation::Challenge.def())
     .join(JoinType::InnerJoin, challenge::Relation::Game.def())
-    .join(JoinType::LeftJoin, Relation::Team.def())
-    .filter(Column::UserId.eq(user_id))
-    .filter(Column::TeamId.is_not_null())
-    .filter(team::Column::State.gte(team::State::Hidden));
+    .filter(Column::UserId.eq(user_id));
   if let Some(game_id) = game_id {
     sql_total = sql_total.filter(challenge::Column::GameId.eq(game_id));
   }
@@ -406,10 +403,7 @@ where
 
   let mut sql_solved = Entity::find()
     .join(JoinType::InnerJoin, Relation::Challenge.def())
-    .join(JoinType::LeftJoin, Relation::Team.def())
     .filter(Column::UserId.eq(user_id))
-    .filter(Column::TeamId.is_not_null())
-    .filter(team::Column::State.gte(team::State::Hidden))
     .filter(Column::Solved.eq(true));
   if let Some(game_id) = game_id {
     sql_solved = sql_solved.filter(challenge::Column::GameId.eq(game_id));
@@ -428,8 +422,6 @@ where
     .join(JoinType::InnerJoin, Relation::Challenge.def())
     .join(JoinType::LeftJoin, Relation::Team.def())
     .filter(Column::UserId.eq(user_id))
-    .filter(Column::TeamId.is_not_null())
-    .filter(team::Column::State.gte(team::State::Hidden))
     .distinct_on([(Entity, Column::ChallengeId)])
     .order_by_asc(Column::ChallengeId)
     .order_by_desc(Column::CreatedAt)

--- a/crates/database/src/entities/submission.rs
+++ b/crates/database/src/entities/submission.rs
@@ -309,7 +309,15 @@ where
     sql = sql.filter(Column::Solved.eq(true));
   }
   sql = sql.column_as(challenge::Column::Score, "score");
-  if !only_solved {
+  if only_solved {
+    sql = sql
+      .distinct_on([Column::ChallengeId, Column::TeamId, Column::UserId])
+      .order_by_asc(Column::ChallengeId)
+      .order_by_asc(Column::TeamId)
+      .order_by_asc(Column::UserId)
+      .order_by_asc(Column::CreatedAt)
+      .order_by_asc(Column::Id);
+  } else {
     sql = sql.order_by_desc(Column::CreatedAt);
   }
   let paginator = sql.into_model().paginate(db, page_size);

--- a/crates/database/src/entities/submission.rs
+++ b/crates/database/src/entities/submission.rs
@@ -309,7 +309,9 @@ where
     sql = sql.filter(Column::Solved.eq(true));
   }
   sql = sql.column_as(challenge::Column::Score, "score");
-  sql = sql.order_by_desc(Column::CreatedAt);
+  if !only_solved {
+    sql = sql.order_by_desc(Column::CreatedAt);
+  }
   let paginator = sql.into_model().paginate(db, page_size);
   let total = paginator.num_items().await?;
   let submissions = paginator.fetch_page(page - 1).await?;
@@ -328,47 +330,86 @@ where
   Ok((submissions, total))
 }
 
-#[allow(clippy::too_many_arguments)]
-pub async fn get_user_solved_challenges<C>(
-  db: &C, page: u64, page_size: u64, game_id: Option<i64>, user_id: i64,
-) -> Result<(Vec<ExModel>, u64), DbErr>
+#[derive(Debug, FromQueryResult)]
+pub struct UserChallengeStats {
+  pub challenge_id: i64,
+  pub challenge_name: String,
+  pub total_submissions: i64,
+  pub solved_count: i64,
+}
+
+#[derive(Debug, FromQueryResult)]
+struct ChallengeTotalStats {
+  pub challenge_id: i64,
+  pub challenge_name: String,
+  pub total_submissions: i64,
+}
+
+#[derive(Debug, FromQueryResult)]
+struct ChallengeSolvedStats {
+  pub challenge_id: i64,
+  pub solved_count: i64,
+}
+
+pub async fn get_user_submission_stats<C>(
+  db: &C, game_id: Option<i64>, user_id: i64,
+) -> Result<Vec<UserChallengeStats>, DbErr>
 where
   C: ConnectionTrait, {
-  let page_size = page_size.max(1);
-  let page = page.max(1);
-  let mut sql = Entity::find()
-    .join(JoinType::LeftJoin, Relation::Team.def())
+  let mut sql_total = Entity::find()
     .join(JoinType::InnerJoin, Relation::Challenge.def())
-    .join(JoinType::InnerJoin, Relation::User.def())
-    .column_as(user::Column::Nickname, "user_name")
-    .column_as(team::Column::Name, "team_name")
-    .column_as(challenge::Column::Name, "challenge_name")
+    .join(JoinType::LeftJoin, Relation::Team.def())
     .filter(Column::UserId.eq(user_id))
-    .filter(Column::Solved.eq(true))
     .filter(Column::TeamId.is_not_null())
     .filter(team::Column::State.gte(team::State::Hidden));
   if let Some(game_id) = game_id {
-    sql = sql.filter(challenge::Column::GameId.eq(game_id));
+    sql_total = sql_total.filter(challenge::Column::GameId.eq(game_id));
   }
-  sql = sql
+  let total_stats = sql_total
+    .select_only()
+    .column_as(Column::ChallengeId, "challenge_id")
+    .column_as(challenge::Column::Name, "challenge_name")
+    .column_as(Column::Id.count(), "total_submissions")
+    .group_by(Column::ChallengeId)
+    .group_by(challenge::Column::Name)
     .order_by_asc(Column::ChallengeId)
-    .order_by_asc(Column::UserId)
-    .order_by_asc(Column::CreatedAt)
-    .order_by_asc(Column::Id)
-    .distinct_on([(Entity, Column::ChallengeId), (Entity, Column::UserId)]);
-  sql = sql.column_as(challenge::Column::Score, "score");
-  let paginator = sql.into_model().paginate(db, page_size);
-  let total = paginator.num_items().await?;
-  let submissions = paginator.fetch_page(page - 1).await?;
-  let submissions = submissions
-    .into_iter()
-    .map(|r| ExModel {
-      content: None,
-      result: None,
-      ..r
-    })
-    .collect();
-  Ok((submissions, total))
+    .into_model::<ChallengeTotalStats>()
+    .all(db)
+    .await?;
+
+  let mut sql_solved = Entity::find()
+    .join(JoinType::InnerJoin, Relation::Challenge.def())
+    .join(JoinType::LeftJoin, Relation::Team.def())
+    .filter(Column::UserId.eq(user_id))
+    .filter(Column::TeamId.is_not_null())
+    .filter(team::Column::State.gte(team::State::Hidden))
+    .filter(Column::Solved.eq(true));
+  if let Some(game_id) = game_id {
+    sql_solved = sql_solved.filter(challenge::Column::GameId.eq(game_id));
+  }
+  let solved_stats = sql_solved
+    .select_only()
+    .column_as(Column::ChallengeId, "challenge_id")
+    .column_as(Column::Id.count(), "solved_count")
+    .group_by(Column::ChallengeId)
+    .order_by_asc(Column::ChallengeId)
+    .into_model::<ChallengeSolvedStats>()
+    .all(db)
+    .await?;
+
+  let mut result = Vec::new();
+  for total in &total_stats {
+    let solved = solved_stats
+      .iter()
+      .find(|s| s.challenge_id == total.challenge_id);
+    result.push(UserChallengeStats {
+      challenge_id: total.challenge_id,
+      challenge_name: total.challenge_name.clone(),
+      total_submissions: total.total_submissions,
+      solved_count: solved.map(|s| s.solved_count).unwrap_or(0),
+    });
+  }
+  Ok(result)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/database/src/entities/submission.rs
+++ b/crates/database/src/entities/submission.rs
@@ -7,7 +7,7 @@ use sea_orm::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::{challenge, team, user};
+use super::{challenge, game, team, user};
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
 #[sea_orm(table_name = "submission")]
 pub struct Model {
@@ -338,18 +338,25 @@ where
   Ok((submissions, total))
 }
 
-#[derive(Debug, FromQueryResult)]
+#[derive(Debug, Serialize, FromQueryResult)]
 pub struct UserChallengeStats {
   pub challenge_id: i64,
   pub challenge_name: String,
+  pub game_id: i64,
+  pub game_name: String,
+  pub team_name: Option<String>,
   pub total_submissions: i64,
   pub solved_count: i64,
+  #[serde(with = "ts_seconds")]
+  pub last_submission_at: DateTime<Utc>,
 }
 
 #[derive(Debug, FromQueryResult)]
 struct ChallengeTotalStats {
   pub challenge_id: i64,
   pub challenge_name: String,
+  pub game_id: i64,
+  pub game_name: String,
   pub total_submissions: i64,
 }
 
@@ -359,6 +366,13 @@ struct ChallengeSolvedStats {
   pub solved_count: i64,
 }
 
+#[derive(Debug, FromQueryResult)]
+struct LastSubmissionInfo {
+  pub challenge_id: i64,
+  pub team_name: Option<String>,
+  pub last_submission_at: DateTime<Utc>,
+}
+
 pub async fn get_user_submission_stats<C>(
   db: &C, game_id: Option<i64>, user_id: i64,
 ) -> Result<Vec<UserChallengeStats>, DbErr>
@@ -366,6 +380,7 @@ where
   C: ConnectionTrait, {
   let mut sql_total = Entity::find()
     .join(JoinType::InnerJoin, Relation::Challenge.def())
+    .join(JoinType::InnerJoin, challenge::Relation::Game.def())
     .join(JoinType::LeftJoin, Relation::Team.def())
     .filter(Column::UserId.eq(user_id))
     .filter(Column::TeamId.is_not_null())
@@ -377,9 +392,13 @@ where
     .select_only()
     .column_as(Column::ChallengeId, "challenge_id")
     .column_as(challenge::Column::Name, "challenge_name")
+    .column_as(challenge::Column::GameId, "game_id")
+    .column_as(game::Column::Name, "game_name")
     .column_as(Column::Id.count(), "total_submissions")
     .group_by(Column::ChallengeId)
     .group_by(challenge::Column::Name)
+    .group_by(challenge::Column::GameId)
+    .group_by(game::Column::Name)
     .order_by_asc(Column::ChallengeId)
     .into_model::<ChallengeTotalStats>()
     .all(db)
@@ -405,16 +424,45 @@ where
     .all(db)
     .await?;
 
+  let mut sql_last = Entity::find()
+    .join(JoinType::InnerJoin, Relation::Challenge.def())
+    .join(JoinType::LeftJoin, Relation::Team.def())
+    .filter(Column::UserId.eq(user_id))
+    .filter(Column::TeamId.is_not_null())
+    .filter(team::Column::State.gte(team::State::Hidden))
+    .distinct_on([(Entity, Column::ChallengeId)])
+    .order_by_asc(Column::ChallengeId)
+    .order_by_desc(Column::CreatedAt)
+    .order_by_desc(Column::Id);
+  if let Some(game_id) = game_id {
+    sql_last = sql_last.filter(challenge::Column::GameId.eq(game_id));
+  }
+  let last_info = sql_last
+    .select_only()
+    .column_as(Column::ChallengeId, "challenge_id")
+    .column_as(team::Column::Name, "team_name")
+    .column_as(Column::CreatedAt, "last_submission_at")
+    .into_model::<LastSubmissionInfo>()
+    .all(db)
+    .await?;
+
   let mut result = Vec::new();
   for total in &total_stats {
     let solved = solved_stats
       .iter()
       .find(|s| s.challenge_id == total.challenge_id);
+    let last = last_info
+      .iter()
+      .find(|l| l.challenge_id == total.challenge_id);
     result.push(UserChallengeStats {
       challenge_id: total.challenge_id,
       challenge_name: total.challenge_name.clone(),
+      game_id: total.game_id,
+      game_name: total.game_name.clone(),
+      team_name: last.and_then(|l| l.team_name.clone()),
       total_submissions: total.total_submissions,
       solved_count: solved.map(|s| s.solved_count).unwrap_or(0),
+      last_submission_at: last.map(|l| l.last_submission_at).unwrap_or_default(),
     });
   }
   Ok(result)

--- a/crates/database/src/entities/submission.rs
+++ b/crates/database/src/entities/submission.rs
@@ -309,9 +309,7 @@ where
     sql = sql.filter(Column::Solved.eq(true));
   }
   sql = sql.column_as(challenge::Column::Score, "score");
-  if !only_solved {
-    sql = sql.order_by_desc(Column::CreatedAt);
-  }
+  sql = sql.order_by_desc(Column::CreatedAt);
   let paginator = sql.into_model().paginate(db, page_size);
   let total = paginator.num_items().await?;
   let submissions = paginator.fetch_page(page - 1).await?;

--- a/crates/database/src/entities/submission.rs
+++ b/crates/database/src/entities/submission.rs
@@ -307,9 +307,27 @@ where
   }
   if only_solved {
     sql = sql.filter(Column::Solved.eq(true));
+    if team_id.is_some() {
+      sql = sql
+        .filter(Column::TeamId.is_not_null())
+        .filter(team::Column::State.gte(team::State::Hidden))
+        .order_by_asc(Column::ChallengeId)
+        .order_by_asc(Column::TeamId)
+        .order_by_asc(Column::CreatedAt)
+        .order_by_asc(Column::Id)
+        .distinct_on([(Entity, Column::ChallengeId), (Entity, Column::TeamId)]);
+    } else {
+      sql = sql
+        .order_by_asc(Column::ChallengeId)
+        .order_by_asc(Column::UserId)
+        .order_by_asc(Column::CreatedAt)
+        .order_by_asc(Column::Id)
+        .distinct_on([(Entity, Column::ChallengeId), (Entity, Column::UserId)]);
+    }
+  } else {
+    sql = sql.order_by_desc(Column::CreatedAt);
   }
   sql = sql.column_as(challenge::Column::Score, "score");
-  sql = sql.order_by_desc(Column::CreatedAt);
   let paginator = sql.into_model().paginate(db, page_size);
   let total = paginator.num_items().await?;
   let submissions = paginator.fetch_page(page - 1).await?;

--- a/crates/database/src/entities/submission.rs
+++ b/crates/database/src/entities/submission.rs
@@ -307,27 +307,11 @@ where
   }
   if only_solved {
     sql = sql.filter(Column::Solved.eq(true));
-    if team_id.is_some() {
-      sql = sql
-        .filter(Column::TeamId.is_not_null())
-        .filter(team::Column::State.gte(team::State::Hidden))
-        .order_by_asc(Column::ChallengeId)
-        .order_by_asc(Column::TeamId)
-        .order_by_asc(Column::CreatedAt)
-        .order_by_asc(Column::Id)
-        .distinct_on([(Entity, Column::ChallengeId), (Entity, Column::TeamId)]);
-    } else {
-      sql = sql
-        .order_by_asc(Column::ChallengeId)
-        .order_by_asc(Column::UserId)
-        .order_by_asc(Column::CreatedAt)
-        .order_by_asc(Column::Id)
-        .distinct_on([(Entity, Column::ChallengeId), (Entity, Column::UserId)]);
-    }
-  } else {
-    sql = sql.order_by_desc(Column::CreatedAt);
   }
   sql = sql.column_as(challenge::Column::Score, "score");
+  if !only_solved {
+    sql = sql.order_by_desc(Column::CreatedAt);
+  }
   let paginator = sql.into_model().paginate(db, page_size);
   let total = paginator.num_items().await?;
   let submissions = paginator.fetch_page(page - 1).await?;
@@ -343,6 +327,49 @@ where
   } else {
     submissions
   };
+  Ok((submissions, total))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn get_user_solved_challenges<C>(
+  db: &C, page: u64, page_size: u64, game_id: Option<i64>, user_id: i64,
+) -> Result<(Vec<ExModel>, u64), DbErr>
+where
+  C: ConnectionTrait, {
+  let page_size = page_size.max(1);
+  let page = page.max(1);
+  let mut sql = Entity::find()
+    .join(JoinType::LeftJoin, Relation::Team.def())
+    .join(JoinType::InnerJoin, Relation::Challenge.def())
+    .join(JoinType::InnerJoin, Relation::User.def())
+    .column_as(user::Column::Nickname, "user_name")
+    .column_as(team::Column::Name, "team_name")
+    .column_as(challenge::Column::Name, "challenge_name")
+    .filter(Column::UserId.eq(user_id))
+    .filter(Column::Solved.eq(true))
+    .filter(Column::TeamId.is_not_null())
+    .filter(team::Column::State.gte(team::State::Hidden));
+  if let Some(game_id) = game_id {
+    sql = sql.filter(challenge::Column::GameId.eq(game_id));
+  }
+  sql = sql
+    .order_by_asc(Column::ChallengeId)
+    .order_by_asc(Column::UserId)
+    .order_by_asc(Column::CreatedAt)
+    .order_by_asc(Column::Id)
+    .distinct_on([(Entity, Column::ChallengeId), (Entity, Column::UserId)]);
+  sql = sql.column_as(challenge::Column::Score, "score");
+  let paginator = sql.into_model().paginate(db, page_size);
+  let total = paginator.num_items().await?;
+  let submissions = paginator.fetch_page(page - 1).await?;
+  let submissions = submissions
+    .into_iter()
+    .map(|r| ExModel {
+      content: None,
+      result: None,
+      ..r
+    })
+    .collect();
   Ok((submissions, total))
 }
 

--- a/crates/server/src/routes/user/mod.rs
+++ b/crates/server/src/routes/user/mod.rs
@@ -281,9 +281,6 @@ async fn get_submission_stats(
     } else {
       entry.failed_submissions += 1;
     }
-    if entry.game_name.is_empty() {
-      entry.game_name = sub.team_name.clone().unwrap_or_default();
-    }
   }
 
   let challenges: Vec<ChallengeStats> = challenge_map.into_values().collect();

--- a/crates/server/src/routes/user/mod.rs
+++ b/crates/server/src/routes/user/mod.rs
@@ -11,7 +11,7 @@ use r2s_database::{
   user::{self, Permission},
 };
 use r2s_migrator::Database;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use tracing::info;
 
 use crate::{
@@ -60,23 +60,6 @@ struct UserListQuery {
 #[derive(Deserialize)]
 struct SubmissionQuery {
   game_id: Option<i64>,
-}
-
-#[derive(Serialize)]
-struct ChallengeStats {
-  challenge_id: i64,
-  challenge_name: String,
-  solved: bool,
-  total_submissions: u64,
-  failed_submissions: u64,
-}
-
-#[derive(Serialize)]
-struct SubmissionStats {
-  total_submissions: u64,
-  total_solved: u64,
-  total_failed: u64,
-  challenges: Vec<ChallengeStats>,
 }
 
 async fn get_user_list(
@@ -228,29 +211,5 @@ async fn get_submission_stats(
     return Err(ResponseError::NotFound("user not found".to_owned()));
   }
   let stats = submission::get_user_submission_stats(&db.conn, query.game_id, user.id).await?;
-
-  let total_submissions: u64 = stats.iter().map(|s| s.total_submissions as u64).sum();
-  let total_solved = stats.iter().filter(|s| s.solved_count > 0).count() as u64;
-  let total_failed: u64 = stats
-    .iter()
-    .map(|s| (s.total_submissions - s.solved_count) as u64)
-    .sum();
-
-  let challenges: Vec<ChallengeStats> = stats
-    .iter()
-    .map(|s| ChallengeStats {
-      challenge_id: s.challenge_id,
-      challenge_name: s.challenge_name.clone(),
-      solved: s.solved_count > 0,
-      total_submissions: s.total_submissions as u64,
-      failed_submissions: (s.total_submissions - s.solved_count) as u64,
-    })
-    .collect();
-
-  Ok(Json(SubmissionStats {
-    total_submissions,
-    total_solved,
-    total_failed,
-    challenges,
-  }))
+  Ok(Json(stats))
 }

--- a/crates/server/src/routes/user/mod.rs
+++ b/crates/server/src/routes/user/mod.rs
@@ -7,11 +7,11 @@ use axum::{
 };
 use r2s_cache::Cache;
 use r2s_database::{
-  ip, oauth, team,
+  ip, oauth, submission, team,
   user::{self, Permission},
 };
 use r2s_migrator::Database;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tracing::info;
 
 use crate::{
@@ -39,6 +39,8 @@ pub fn router(state: &GlobalState) -> Router<GlobalState> {
         )))
         .route("/", get(get_user))
         .route("/team", get(get_teams))
+        .route("/submission", get(get_submissions))
+        .route("/submission/stats", get(get_submission_stats))
         .route_layer(middleware::from_fn_with_state(
           state.clone(),
           data::prepare_data!(user, false, id, account, nickname),
@@ -54,6 +56,31 @@ struct UserListQuery {
   order: Option<String>,
   filter: Option<String>,
   institute_id: Option<i64>,
+}
+
+#[derive(Deserialize)]
+struct SubmissionQuery {
+  page: Option<u64>,
+  page_size: Option<u64>,
+  game_id: Option<i64>,
+}
+
+#[derive(Serialize)]
+struct ChallengeStats {
+  challenge_id: i64,
+  challenge_name: String,
+  game_name: String,
+  solved: bool,
+  total_submissions: u64,
+  failed_submissions: u64,
+}
+
+#[derive(Serialize)]
+struct SubmissionStats {
+  total_submissions: u64,
+  total_solved: u64,
+  total_failed: u64,
+  challenges: Vec<ChallengeStats>,
 }
 
 async fn get_user_list(
@@ -195,4 +222,76 @@ async fn get_oauth_list(
 ) -> Result<impl IntoResponse, ResponseError> {
   let oauths = oauth::get_list_ex(&db.conn, user.id).await?;
   Ok(Json(oauths))
+}
+
+async fn get_submissions(
+  State(ref db): State<Database>, Extension(user): Extension<user::Model>,
+  Query(query): Query<SubmissionQuery>,
+) -> Result<impl IntoResponse, ResponseError> {
+  let (submissions, total) = submission::get_page_ex(
+    &db.conn,
+    page(query.page),
+    page_size(query.page_size, 10),
+    true,
+    false,
+    query.game_id,
+    None,
+    None,
+    Some(user.id),
+  )
+  .await?;
+  Ok(Json((submissions, total)))
+}
+
+async fn get_submission_stats(
+  State(ref db): State<Database>, Extension(user): Extension<user::Model>,
+  Query(query): Query<SubmissionQuery>,
+) -> Result<impl IntoResponse, ResponseError> {
+  let submissions = submission::get_list_ex(
+    &db.conn,
+    false,
+    false,
+    query.game_id,
+    None,
+    None,
+    Some(user.id),
+    true,
+  )
+  .await?;
+
+  use std::collections::HashMap;
+  let mut challenge_map: HashMap<i64, ChallengeStats> = HashMap::new();
+  let mut total_submissions: u64 = 0;
+  let mut total_solved: u64 = 0;
+
+  for sub in &submissions {
+    total_submissions += 1;
+    let entry = challenge_map.entry(sub.challenge_id).or_insert(ChallengeStats {
+      challenge_id: sub.challenge_id,
+      challenge_name: sub.challenge_name.clone().unwrap_or_default(),
+      game_name: String::new(),
+      solved: false,
+      total_submissions: 0,
+      failed_submissions: 0,
+    });
+    entry.total_submissions += 1;
+    if sub.solved == Some(true) {
+      entry.solved = true;
+      total_solved += 1;
+    } else {
+      entry.failed_submissions += 1;
+    }
+    if entry.game_name.is_empty() {
+      entry.game_name = sub.team_name.clone().unwrap_or_default();
+    }
+  }
+
+  let challenges: Vec<ChallengeStats> = challenge_map.into_values().collect();
+  let stats = SubmissionStats {
+    total_submissions,
+    total_solved,
+    total_failed: total_submissions.saturating_sub(total_solved),
+    challenges,
+  };
+  Ok(Json(stats))
 }

--- a/crates/server/src/routes/user/mod.rs
+++ b/crates/server/src/routes/user/mod.rs
@@ -39,8 +39,7 @@ pub fn router(state: &GlobalState) -> Router<GlobalState> {
         )))
         .route("/", get(get_user))
         .route("/team", get(get_teams))
-        .route("/submission", get(get_submissions))
-        .route("/submission/stats", get(get_submission_stats))
+        .route("/stats", get(get_submission_stats))
         .route_layer(middleware::from_fn_with_state(
           state.clone(),
           data::prepare_data!(user, false, id, account, nickname),
@@ -60,8 +59,6 @@ struct UserListQuery {
 
 #[derive(Deserialize)]
 struct SubmissionQuery {
-  page: Option<u64>,
-  page_size: Option<u64>,
   game_id: Option<i64>,
 }
 
@@ -223,24 +220,6 @@ async fn get_oauth_list(
   Ok(Json(oauths))
 }
 
-async fn get_submissions(
-  State(ref db): State<Database>, Extension(token): Extension<Token>,
-  Extension(user): Extension<user::Model>, Query(query): Query<SubmissionQuery>,
-) -> Result<impl IntoResponse, ResponseError> {
-  if user.hidden && !token.permissions.0.contains(&Permission::User) && token.id != user.id {
-    return Err(ResponseError::NotFound("user not found".to_owned()));
-  }
-  let (submissions, total) = submission::get_user_solved_challenges(
-    &db.conn,
-    page(query.page),
-    page_size(query.page_size, 10),
-    query.game_id,
-    user.id,
-  )
-  .await?;
-  Ok(Json((submissions, total)))
-}
-
 async fn get_submission_stats(
   State(ref db): State<Database>, Extension(token): Extension<Token>,
   Extension(user): Extension<user::Model>, Query(query): Query<SubmissionQuery>,
@@ -248,51 +227,30 @@ async fn get_submission_stats(
   if user.hidden && !token.permissions.0.contains(&Permission::User) && token.id != user.id {
     return Err(ResponseError::NotFound("user not found".to_owned()));
   }
-  let submissions = submission::get_list_ex(
-    &db.conn,
-    false,
-    false,
-    query.game_id,
-    None,
-    None,
-    Some(user.id),
-    false,
-  )
-  .await?;
+  let stats = submission::get_user_submission_stats(&db.conn, query.game_id, user.id).await?;
 
-  use std::collections::HashMap;
-  let mut challenge_map: HashMap<i64, ChallengeStats> = HashMap::new();
-  let mut total_submissions: u64 = 0;
-  let mut solved_challenges: std::collections::HashSet<i64> = std::collections::HashSet::new();
+  let total_submissions: u64 = stats.iter().map(|s| s.total_submissions as u64).sum();
+  let total_solved = stats.iter().filter(|s| s.solved_count > 0).count() as u64;
+  let total_failed: u64 = stats
+    .iter()
+    .map(|s| (s.total_submissions - s.solved_count) as u64)
+    .sum();
 
-  for sub in &submissions {
-    total_submissions += 1;
-    let entry = challenge_map
-      .entry(sub.challenge_id)
-      .or_insert(ChallengeStats {
-        challenge_id: sub.challenge_id,
-        challenge_name: sub.challenge_name.clone().unwrap_or_default(),
-        solved: false,
-        total_submissions: 0,
-        failed_submissions: 0,
-      });
-    entry.total_submissions += 1;
-    if sub.solved == Some(true) {
-      entry.solved = true;
-      solved_challenges.insert(sub.challenge_id);
-    } else if sub.solved == Some(false) {
-      entry.failed_submissions += 1;
-    }
-  }
+  let challenges: Vec<ChallengeStats> = stats
+    .iter()
+    .map(|s| ChallengeStats {
+      challenge_id: s.challenge_id,
+      challenge_name: s.challenge_name.clone(),
+      solved: s.solved_count > 0,
+      total_submissions: s.total_submissions as u64,
+      failed_submissions: (s.total_submissions - s.solved_count) as u64,
+    })
+    .collect();
 
-  let total_solved = solved_challenges.len() as u64;
-  let total_failed = total_submissions - total_solved;
-  let challenges: Vec<ChallengeStats> = challenge_map.into_values().collect();
-  let stats = SubmissionStats {
+  Ok(Json(SubmissionStats {
     total_submissions,
     total_solved,
     total_failed,
     challenges,
-  };
-  Ok(Json(stats))
+  }))
 }

--- a/crates/server/src/routes/user/mod.rs
+++ b/crates/server/src/routes/user/mod.rs
@@ -69,7 +69,6 @@ struct SubmissionQuery {
 struct ChallengeStats {
   challenge_id: i64,
   challenge_name: String,
-  game_name: String,
   solved: bool,
   total_submissions: u64,
   failed_submissions: u64,
@@ -225,28 +224,30 @@ async fn get_oauth_list(
 }
 
 async fn get_submissions(
-  State(ref db): State<Database>, Extension(user): Extension<user::Model>,
-  Query(query): Query<SubmissionQuery>,
+  State(ref db): State<Database>, Extension(token): Extension<Token>,
+  Extension(user): Extension<user::Model>, Query(query): Query<SubmissionQuery>,
 ) -> Result<impl IntoResponse, ResponseError> {
-  let (submissions, total) = submission::get_page_ex(
+  if user.hidden && !token.permissions.0.contains(&Permission::User) && token.id != user.id {
+    return Err(ResponseError::NotFound("user not found".to_owned()));
+  }
+  let (submissions, total) = submission::get_user_solved_challenges(
     &db.conn,
     page(query.page),
     page_size(query.page_size, 10),
-    true,
-    false,
     query.game_id,
-    None,
-    None,
-    Some(user.id),
+    user.id,
   )
   .await?;
   Ok(Json((submissions, total)))
 }
 
 async fn get_submission_stats(
-  State(ref db): State<Database>, Extension(user): Extension<user::Model>,
-  Query(query): Query<SubmissionQuery>,
+  State(ref db): State<Database>, Extension(token): Extension<Token>,
+  Extension(user): Extension<user::Model>, Query(query): Query<SubmissionQuery>,
 ) -> Result<impl IntoResponse, ResponseError> {
+  if user.hidden && !token.permissions.0.contains(&Permission::User) && token.id != user.id {
+    return Err(ResponseError::NotFound("user not found".to_owned()));
+  }
   let submissions = submission::get_list_ex(
     &db.conn,
     false,
@@ -255,39 +256,42 @@ async fn get_submission_stats(
     None,
     None,
     Some(user.id),
-    true,
+    false,
   )
   .await?;
 
   use std::collections::HashMap;
   let mut challenge_map: HashMap<i64, ChallengeStats> = HashMap::new();
   let mut total_submissions: u64 = 0;
-  let mut total_solved: u64 = 0;
+  let mut solved_challenges: std::collections::HashSet<i64> = std::collections::HashSet::new();
 
   for sub in &submissions {
     total_submissions += 1;
-    let entry = challenge_map.entry(sub.challenge_id).or_insert(ChallengeStats {
-      challenge_id: sub.challenge_id,
-      challenge_name: sub.challenge_name.clone().unwrap_or_default(),
-      game_name: String::new(),
-      solved: false,
-      total_submissions: 0,
-      failed_submissions: 0,
-    });
+    let entry = challenge_map
+      .entry(sub.challenge_id)
+      .or_insert(ChallengeStats {
+        challenge_id: sub.challenge_id,
+        challenge_name: sub.challenge_name.clone().unwrap_or_default(),
+        solved: false,
+        total_submissions: 0,
+        failed_submissions: 0,
+      });
     entry.total_submissions += 1;
     if sub.solved == Some(true) {
       entry.solved = true;
-      total_solved += 1;
-    } else {
+      solved_challenges.insert(sub.challenge_id);
+    } else if sub.solved == Some(false) {
       entry.failed_submissions += 1;
     }
   }
 
+  let total_solved = solved_challenges.len() as u64;
+  let total_failed = total_submissions - total_solved;
   let challenges: Vec<ChallengeStats> = challenge_map.into_values().collect();
   let stats = SubmissionStats {
     total_submissions,
     total_solved,
-    total_failed: total_submissions.saturating_sub(total_solved),
+    total_failed,
     challenges,
   };
   Ok(Json(stats))

--- a/web/src/lib/api/user.ts
+++ b/web/src/lib/api/user.ts
@@ -253,13 +253,7 @@ export function useUserSubmissions({
   return useQuery(
     () => ({
       queryKey: keys(),
-      queryFn: async () =>
-        await getUserSubmissions(
-          id(),
-          page() ?? 1,
-          page_size() ?? 10,
-          game_id?.() ?? undefined
-        ),
+      queryFn: async () => await getUserSubmissions(id(), page() ?? 1, page_size() ?? 10, game_id?.() ?? undefined),
       enabled: enabled?.(),
       throwOnError: (err: Error) => {
         handleHttpError(err, t("user.errors.fetchSubmissions.title"));
@@ -281,7 +275,6 @@ export type GameStats = {
 export type ChallengeStats = {
   challenge_id: number;
   challenge_name: string;
-  game_name: string;
   solved: boolean;
   total_submissions: number;
   failed_submissions: number;

--- a/web/src/lib/api/user.ts
+++ b/web/src/lib/api/user.ts
@@ -5,9 +5,9 @@ import type { User } from "@models/user";
 import { t } from "@storage/theme";
 import { useMutation, useQuery } from "@tanstack/solid-query";
 import type { SearchParamsOption } from "ky";
+import type { DateTime } from "luxon";
 import { createMemo } from "solid-js";
 import api, { api_root, handleHttpError, inflyClient, safeJson, toastSuccess } from ".";
-import type { DateTime } from "luxon";
 
 export async function getUserList(
   page?: number,

--- a/web/src/lib/api/user.ts
+++ b/web/src/lib/api/user.ts
@@ -7,6 +7,7 @@ import { useMutation, useQuery } from "@tanstack/solid-query";
 import type { SearchParamsOption } from "ky";
 import { createMemo } from "solid-js";
 import api, { api_root, handleHttpError, inflyClient, safeJson, toastSuccess } from ".";
+import type { DateTime } from "luxon";
 
 export async function getUserList(
   page?: number,
@@ -227,7 +228,7 @@ export type ChallengeStats = {
   team_name: string | null;
   total_submissions: number;
   solved_count: number;
-  last_submission_at: number;
+  last_submission_at: DateTime;
 };
 
 export async function getUserSubmissionStats(id: number, game_id?: number) {

--- a/web/src/lib/api/user.ts
+++ b/web/src/lib/api/user.ts
@@ -1,5 +1,6 @@
 import type { Ip } from "@models/ip";
 import type { OAuth } from "@models/oauth";
+import type { Submission } from "@models/submission";
 import type { Team } from "@models/team";
 import type { User } from "@models/user";
 import { t } from "@storage/theme";
@@ -212,6 +213,118 @@ export function useUserOAuthList({
       enabled: enabled?.(),
       throwOnError: (err: Error) => {
         handleHttpError(err, t("user.errors.fetchOAuth.title"));
+        return onError?.(err) ?? false;
+      },
+    }),
+    () => inflyClient
+  );
+}
+
+export async function getUserSubmissions(id: number, page?: number, page_size?: number, game_id?: number) {
+  return await api
+    .get(`${api_root}/user/${id}/submission`, {
+      searchParams: JSON.parse(
+        JSON.stringify({
+          page,
+          page_size,
+          game_id,
+        })
+      ) as SearchParamsOption,
+    })
+    .json<[Submission[], number]>();
+}
+
+export function useUserSubmissions({
+  id,
+  page,
+  page_size,
+  game_id,
+  enabled,
+  onError,
+}: {
+  id: () => number;
+  page: () => number;
+  page_size: () => number;
+  game_id?: () => number | null;
+  enabled?: () => boolean;
+  onError?: (err: Error) => boolean;
+}) {
+  const keys = createMemo(() => ["user", id(), "submissions", page(), page_size(), game_id?.()]);
+  return useQuery(
+    () => ({
+      queryKey: keys(),
+      queryFn: async () =>
+        await getUserSubmissions(
+          id(),
+          page() ?? 1,
+          page_size() ?? 10,
+          game_id?.() ?? undefined
+        ),
+      enabled: enabled?.(),
+      throwOnError: (err: Error) => {
+        handleHttpError(err, t("user.errors.fetchSubmissions.title"));
+        return onError?.(err) ?? false;
+      },
+    }),
+    () => inflyClient
+  );
+}
+
+export type GameStats = {
+  game_id: number;
+  game_name: string;
+  total_submissions: number;
+  solved: number;
+  failed: number;
+};
+
+export type ChallengeStats = {
+  challenge_id: number;
+  challenge_name: string;
+  game_name: string;
+  solved: boolean;
+  total_submissions: number;
+  failed_submissions: number;
+};
+
+export type SubmissionStats = {
+  total_submissions: number;
+  total_solved: number;
+  total_failed: number;
+  challenges: ChallengeStats[];
+};
+
+export async function getUserSubmissionStats(id: number, game_id?: number) {
+  return await api
+    .get(`${api_root}/user/${id}/submission/stats`, {
+      searchParams: JSON.parse(
+        JSON.stringify({
+          game_id,
+        })
+      ) as SearchParamsOption,
+    })
+    .json<SubmissionStats>();
+}
+
+export function useUserSubmissionStats({
+  id,
+  game_id,
+  enabled,
+  onError,
+}: {
+  id: () => number;
+  game_id?: () => number | null;
+  enabled?: () => boolean;
+  onError?: (err: Error) => boolean;
+}) {
+  const keys = createMemo(() => ["user", id(), "submission-stats", game_id?.()]);
+  return useQuery(
+    () => ({
+      queryKey: keys(),
+      queryFn: async () => await getUserSubmissionStats(id(), game_id?.() ?? undefined),
+      enabled: enabled?.(),
+      throwOnError: (err: Error) => {
+        handleHttpError(err, t("user.errors.fetchSubmissions.title"));
         return onError?.(err) ?? false;
       },
     }),

--- a/web/src/lib/api/user.ts
+++ b/web/src/lib/api/user.ts
@@ -1,6 +1,5 @@
 import type { Ip } from "@models/ip";
 import type { OAuth } from "@models/oauth";
-import type { Submission } from "@models/submission";
 import type { Team } from "@models/team";
 import type { User } from "@models/user";
 import { t } from "@storage/theme";
@@ -220,58 +219,6 @@ export function useUserOAuthList({
   );
 }
 
-export async function getUserSubmissions(id: number, page?: number, page_size?: number, game_id?: number) {
-  return await api
-    .get(`${api_root}/user/${id}/submission`, {
-      searchParams: JSON.parse(
-        JSON.stringify({
-          page,
-          page_size,
-          game_id,
-        })
-      ) as SearchParamsOption,
-    })
-    .json<[Submission[], number]>();
-}
-
-export function useUserSubmissions({
-  id,
-  page,
-  page_size,
-  game_id,
-  enabled,
-  onError,
-}: {
-  id: () => number;
-  page: () => number;
-  page_size: () => number;
-  game_id?: () => number | null;
-  enabled?: () => boolean;
-  onError?: (err: Error) => boolean;
-}) {
-  const keys = createMemo(() => ["user", id(), "submissions", page(), page_size(), game_id?.()]);
-  return useQuery(
-    () => ({
-      queryKey: keys(),
-      queryFn: async () => await getUserSubmissions(id(), page() ?? 1, page_size() ?? 10, game_id?.() ?? undefined),
-      enabled: enabled?.(),
-      throwOnError: (err: Error) => {
-        handleHttpError(err, t("user.errors.fetchSubmissions.title"));
-        return onError?.(err) ?? false;
-      },
-    }),
-    () => inflyClient
-  );
-}
-
-export type GameStats = {
-  game_id: number;
-  game_name: string;
-  total_submissions: number;
-  solved: number;
-  failed: number;
-};
-
 export type ChallengeStats = {
   challenge_id: number;
   challenge_name: string;
@@ -289,7 +236,7 @@ export type SubmissionStats = {
 
 export async function getUserSubmissionStats(id: number, game_id?: number) {
   return await api
-    .get(`${api_root}/user/${id}/submission/stats`, {
+    .get(`${api_root}/user/${id}/stats`, {
       searchParams: JSON.parse(
         JSON.stringify({
           game_id,

--- a/web/src/lib/api/user.ts
+++ b/web/src/lib/api/user.ts
@@ -222,16 +222,12 @@ export function useUserOAuthList({
 export type ChallengeStats = {
   challenge_id: number;
   challenge_name: string;
-  solved: boolean;
+  game_id: number;
+  game_name: string;
+  team_name: string | null;
   total_submissions: number;
-  failed_submissions: number;
-};
-
-export type SubmissionStats = {
-  total_submissions: number;
-  total_solved: number;
-  total_failed: number;
-  challenges: ChallengeStats[];
+  solved_count: number;
+  last_submission_at: number;
 };
 
 export async function getUserSubmissionStats(id: number, game_id?: number) {
@@ -243,7 +239,7 @@ export async function getUserSubmissionStats(id: number, game_id?: number) {
         })
       ) as SearchParamsOption,
     })
-    .json<SubmissionStats>();
+    .json<ChallengeStats[]>();
 }
 
 export function useUserSubmissionStats({

--- a/web/src/lib/i18n/en-us.json
+++ b/web/src/lib/i18n/en-us.json
@@ -1529,8 +1529,11 @@
       "title": "Submission Records",
       "allGames": "All Games",
       "challenge": "Challenge",
+      "game": "Game",
+      "team": "Team",
       "submissions": "Submissions",
       "status": "Status",
+      "time": "Time",
       "empty": "No submission records yet",
       "solved": "Solved",
       "failed": "Failed"

--- a/web/src/lib/i18n/en-us.json
+++ b/web/src/lib/i18n/en-us.json
@@ -1513,6 +1513,9 @@
       },
       "fetch": {
         "title": "Failed to fetch user information"
+      },
+      "fetchSubmissions": {
+        "title": "Failed to fetch submission records"
       }
     },
     "description": {
@@ -1522,6 +1525,19 @@
     "joinedGames": "Joined games",
     "gameJournal": "Joined in {{game}} as a member of {{team}}.",
     "moreJournal": "Life continues, exploration never stops...",
+    "submissions": {
+      "title": "Solved Challenges",
+      "allGames": "All Games",
+      "challenge": "Challenge",
+      "game": "Game",
+      "team": "Team",
+      "score": "Score",
+      "status": "Status",
+      "time": "Time",
+      "empty": "No solved challenges yet",
+      "solved": "Solved",
+      "failed": "Failed"
+    },
     "gotoAdminPanel": "Go to User Management",
     "registeredAt": "Registered at {{time}}",
     "title": "Users",

--- a/web/src/lib/i18n/en-us.json
+++ b/web/src/lib/i18n/en-us.json
@@ -1529,11 +1529,8 @@
       "title": "Solved Challenges",
       "allGames": "All Games",
       "challenge": "Challenge",
-      "game": "Game",
-      "team": "Team",
-      "score": "Score",
+      "submissions": "Submissions",
       "status": "Status",
-      "time": "Time",
       "empty": "No solved challenges yet",
       "solved": "Solved",
       "failed": "Failed"

--- a/web/src/lib/i18n/en-us.json
+++ b/web/src/lib/i18n/en-us.json
@@ -1533,7 +1533,7 @@
       "team": "Team",
       "submissions": "Submissions",
       "status": "Status",
-      "time": "Time",
+      "time": "Submission Time",
       "empty": "No submission records yet",
       "solved": "Solved",
       "failed": "Failed"

--- a/web/src/lib/i18n/en-us.json
+++ b/web/src/lib/i18n/en-us.json
@@ -1526,12 +1526,12 @@
     "gameJournal": "Joined in {{game}} as a member of {{team}}.",
     "moreJournal": "Life continues, exploration never stops...",
     "submissions": {
-      "title": "Solved Challenges",
+      "title": "Submission Records",
       "allGames": "All Games",
       "challenge": "Challenge",
       "submissions": "Submissions",
       "status": "Status",
-      "empty": "No solved challenges yet",
+      "empty": "No submission records yet",
       "solved": "Solved",
       "failed": "Failed"
     },

--- a/web/src/lib/i18n/ja-jp.json
+++ b/web/src/lib/i18n/ja-jp.json
@@ -1529,8 +1529,11 @@
       "title": "解答記録",
       "allGames": "すべての大会",
       "challenge": "問題",
+      "game": "大会",
+      "team": "チーム",
       "submissions": "提出回数",
       "status": "ステータス",
+      "time": "時間",
       "empty": "解答記録はありません",
       "solved": "解答済み",
       "failed": "未解答"

--- a/web/src/lib/i18n/ja-jp.json
+++ b/web/src/lib/i18n/ja-jp.json
@@ -1513,6 +1513,9 @@
       },
       "fetch": {
         "title": "ユーザー情報の取得に失敗しました"
+      },
+      "fetchSubmissions": {
+        "title": "解答記録の取得に失敗しました"
       }
     },
     "description": {
@@ -1522,6 +1525,19 @@
     "joinedGames": "大会に参加",
     "gameJournal": "{{team}}のメンバーとして{{game}}に参加しました。",
     "moreJournal": "命ある限り、探求を止めない……",
+    "submissions": {
+      "title": "解答記録",
+      "allGames": "すべての大会",
+      "challenge": "問題",
+      "game": "大会",
+      "team": "チーム",
+      "score": "スコア",
+      "status": "ステータス",
+      "time": "提出時間",
+      "empty": "解答記録はありません",
+      "solved": "解答済み",
+      "failed": "未解答"
+    },
     "gotoAdminPanel": "ユーザー管理へ移動",
     "registeredAt": "{{time}}に登録",
     "title": "ユーザー",

--- a/web/src/lib/i18n/ja-jp.json
+++ b/web/src/lib/i18n/ja-jp.json
@@ -1529,11 +1529,8 @@
       "title": "解答記録",
       "allGames": "すべての大会",
       "challenge": "問題",
-      "game": "大会",
-      "team": "チーム",
-      "score": "スコア",
+      "submissions": "提出回数",
       "status": "ステータス",
-      "time": "提出時間",
       "empty": "解答記録はありません",
       "solved": "解答済み",
       "failed": "未解答"

--- a/web/src/lib/i18n/ja-jp.json
+++ b/web/src/lib/i18n/ja-jp.json
@@ -1533,7 +1533,7 @@
       "team": "チーム",
       "submissions": "提出回数",
       "status": "ステータス",
-      "time": "時間",
+      "time": "提出時間",
       "empty": "解答記録はありません",
       "solved": "解答済み",
       "failed": "未解答"

--- a/web/src/lib/i18n/zh-cn.json
+++ b/web/src/lib/i18n/zh-cn.json
@@ -1529,11 +1529,8 @@
       "title": "解题记录",
       "allGames": "全部赛事",
       "challenge": "题目",
-      "game": "赛事",
-      "team": "队伍",
-      "score": "分数",
+      "submissions": "提交次数",
       "status": "状态",
-      "time": "提交时间",
       "empty": "暂无解题记录",
       "solved": "已解出",
       "failed": "未解出"

--- a/web/src/lib/i18n/zh-cn.json
+++ b/web/src/lib/i18n/zh-cn.json
@@ -1513,6 +1513,9 @@
       },
       "fetch": {
         "title": "获取用户信息失败"
+      },
+      "fetchSubmissions": {
+        "title": "获取解题记录失败"
       }
     },
     "description": {
@@ -1522,6 +1525,19 @@
     "joinedGames": "参与赛事",
     "gameJournal": "作为 {{team}} 成员参与了 {{game}}。",
     "moreJournal": "生命不息，探索不止……",
+    "submissions": {
+      "title": "解题记录",
+      "allGames": "全部赛事",
+      "challenge": "题目",
+      "game": "赛事",
+      "team": "队伍",
+      "score": "分数",
+      "status": "状态",
+      "time": "提交时间",
+      "empty": "暂无解题记录",
+      "solved": "已解出",
+      "failed": "未解出"
+    },
     "gotoAdminPanel": "转至用户管理",
     "registeredAt": "注册于 {{time}}",
     "title": "用户",

--- a/web/src/lib/i18n/zh-cn.json
+++ b/web/src/lib/i18n/zh-cn.json
@@ -1533,7 +1533,7 @@
       "team": "队伍",
       "submissions": "提交次数",
       "status": "状态",
-      "time": "时间",
+      "time": "提交时间",
       "empty": "暂无解题记录",
       "solved": "已解出",
       "failed": "未解出"

--- a/web/src/lib/i18n/zh-cn.json
+++ b/web/src/lib/i18n/zh-cn.json
@@ -1529,8 +1529,11 @@
       "title": "解题记录",
       "allGames": "全部赛事",
       "challenge": "题目",
+      "game": "赛事",
+      "team": "队伍",
       "submissions": "提交次数",
       "status": "状态",
+      "time": "时间",
       "empty": "暂无解题记录",
       "solved": "已解出",
       "failed": "未解出"

--- a/web/src/lib/i18n/zh-tw.json
+++ b/web/src/lib/i18n/zh-tw.json
@@ -1529,8 +1529,11 @@
       "title": "解題記錄",
       "allGames": "全部賽事",
       "challenge": "題目",
+      "game": "賽事",
+      "team": "隊伍",
       "submissions": "提交次數",
       "status": "狀態",
+      "time": "時間",
       "empty": "暫無解題記錄",
       "solved": "已解出",
       "failed": "未解出"

--- a/web/src/lib/i18n/zh-tw.json
+++ b/web/src/lib/i18n/zh-tw.json
@@ -1529,11 +1529,8 @@
       "title": "解題記錄",
       "allGames": "全部賽事",
       "challenge": "題目",
-      "game": "賽事",
-      "team": "隊伍",
-      "score": "分數",
+      "submissions": "提交次數",
       "status": "狀態",
-      "time": "提交時間",
       "empty": "暫無解題記錄",
       "solved": "已解出",
       "failed": "未解出"

--- a/web/src/lib/i18n/zh-tw.json
+++ b/web/src/lib/i18n/zh-tw.json
@@ -1513,6 +1513,9 @@
       },
       "fetch": {
         "title": "獲取用戶信息失敗"
+      },
+      "fetchSubmissions": {
+        "title": "獲取解題記錄失敗"
       }
     },
     "description": {
@@ -1522,6 +1525,19 @@
     "joinedGames": "參與賽事",
     "gameJournal": "作為 {{team}} 成員參與了 {{game}}。",
     "moreJournal": "生命不息，探索不止……",
+    "submissions": {
+      "title": "解題記錄",
+      "allGames": "全部賽事",
+      "challenge": "題目",
+      "game": "賽事",
+      "team": "隊伍",
+      "score": "分數",
+      "status": "狀態",
+      "time": "提交時間",
+      "empty": "暫無解題記錄",
+      "solved": "已解出",
+      "failed": "未解出"
+    },
     "gotoAdminPanel": "轉至用戶管理",
     "registeredAt": "註冊於 {{time}}",
     "title": "用戶",

--- a/web/src/lib/i18n/zh-tw.json
+++ b/web/src/lib/i18n/zh-tw.json
@@ -1533,7 +1533,7 @@
       "team": "隊伍",
       "submissions": "提交次數",
       "status": "狀態",
-      "time": "時間",
+      "time": "提交時間",
       "empty": "暫無解題記錄",
       "solved": "已解出",
       "failed": "未解出"

--- a/web/src/routes/_blocks/user-box.tsx
+++ b/web/src/routes/_blocks/user-box.tsx
@@ -1,6 +1,6 @@
 import { useAccountProfile, useLogoutMutation } from "@api/account";
 import { mediaPath } from "@lib/utils/media";
-import { useNavigate } from "@solidjs/router";
+import { useNavigate, useParams } from "@solidjs/router";
 import { accountStore, resetUser } from "@storage/account";
 import { t } from "@storage/theme";
 import { clearToasts } from "@storage/toast";
@@ -15,6 +15,7 @@ import UserCodeDialog from "./user-code-dialog";
 
 export default function UserBox() {
   const navigate = useNavigate();
+  const params = useParams();
 
   const profile = useAccountProfile({ enabled: () => !!accountStore.token });
   const userId = createMemo(() => profile.data?.id ?? accountStore.id ?? null);
@@ -24,7 +25,9 @@ export default function UserBox() {
 
   const userHref = createMemo(() => {
     const id = userId();
-    return id == null ? "/users" : `/users/${id}`;
+    if (id == null) return "/users";
+    const gameId = params.game;
+    return gameId ? `/users/${id}?game=${gameId}` : `/users/${id}`;
   });
 
   const userIdHex = createMemo(() => {

--- a/web/src/routes/games/[game]/teams/[team]/_blocks/sidebar.tsx
+++ b/web/src/routes/games/[game]/teams/[team]/_blocks/sidebar.tsx
@@ -1,7 +1,7 @@
 import { mediaPath } from "@lib/utils/media";
 import type { Team } from "@models/team";
 import type { User } from "@models/user";
-import { A } from "@solidjs/router";
+import { A, useParams } from "@solidjs/router";
 import { fullTheme, t } from "@storage/theme";
 import Avatar from "@widgets/avatar";
 import Divider from "@widgets/divider";
@@ -10,6 +10,9 @@ import { OverlayScrollbarsComponent } from "overlayscrollbars-solid";
 import { For, Show } from "solid-js";
 
 export default function (props: { team: Team | null; members: User[]; loading?: boolean }) {
+  const params = useParams();
+  const gameId = () => params.game;
+
   return (
     <div class="w-full h-full overflow-hidden">
       <OverlayScrollbarsComponent
@@ -51,7 +54,7 @@ export default function (props: { team: Team | null; members: User[]; loading?: 
               <>
                 <A
                   class="px-2 py-2 flex items-center font-bold space-x-4 group cursor-pointer"
-                  href={`/users/${member.id}`}
+                  href={`/users/${member.id}?game=${gameId()}`}
                 >
                   <Avatar
                     class="w-6 h-6"

--- a/web/src/routes/users/[user]/index.tsx
+++ b/web/src/routes/users/[user]/index.tsx
@@ -71,8 +71,8 @@ export default function () {
 
   const chartOption = createMemo(() => {
     const stats = submissionStats.data;
-    if (!stats || stats.challenges.length === 0) return null;
-    const sortedChallenges = [...stats.challenges].sort((a, b) => b.total_submissions - a.total_submissions);
+    if (!stats || stats.length === 0) return null;
+    const sortedChallenges = [...stats].sort((a, b) => b.total_submissions - a.total_submissions);
     return {
       grid: {
         left: "16px",
@@ -105,7 +105,7 @@ export default function () {
           name: t("user.submissions.solved"),
           type: "bar",
           stack: "total",
-          data: sortedChallenges.map((c) => (c.solved ? 1 : 0)),
+          data: sortedChallenges.map((c) => (c.solved_count > 0 ? 1 : 0)),
           itemStyle: {
             color: "#17a750",
           },
@@ -115,7 +115,7 @@ export default function () {
           name: t("user.submissions.failed"),
           type: "bar",
           stack: "total",
-          data: sortedChallenges.map((c) => c.failed_submissions),
+          data: sortedChallenges.map((c) => c.total_submissions - c.solved_count),
           itemStyle: {
             color: "#808080",
           },
@@ -200,7 +200,7 @@ export default function () {
                 <Match when={submissionStats.isLoading}>
                   <LoadingTips />
                 </Match>
-                <Match when={!submissionStats.data || submissionStats.data.challenges.length === 0}>
+                <Match when={!submissionStats.data || submissionStats.data.length === 0}>
                   <div class="h-12 flex items-center justify-center opacity-60">
                     <span>{t("user.submissions.empty")}</span>
                   </div>
@@ -211,25 +211,36 @@ export default function () {
                       <thead>
                         <tr class="border-b border-b-layer-content/15">
                           <th class="text-start h-10 font-normal opacity-60">{t("user.submissions.challenge")}</th>
-                          <th class="text-end h-10 font-normal opacity-60">{t("user.submissions.submissions")}</th>
+                          <th class="text-start h-10 font-normal opacity-60">{t("user.submissions.game")}</th>
+                          <th class="text-start h-10 font-normal opacity-60">{t("user.submissions.team")}</th>
                           <th class="text-center h-10 font-normal opacity-60">{t("user.submissions.status")}</th>
+                          <th class="text-end h-10 font-normal opacity-60">{t("user.submissions.time")}</th>
                         </tr>
                       </thead>
                       <tbody>
-                        <For each={submissionStats.data!.challenges}>
+                        <For each={submissionStats.data!}>
                           {(challenge) => (
                             <tr class="border-b border-b-layer-content/10 hover:bg-layer-content/5">
                               <td class="text-start py-3">
-                                <span class="opacity-60">{challenge.challenge_name}</span>
+                                <A
+                                  class="link-primary hover:underline"
+                                  href={`/games/${challenge.game_id}/challenges/${challenge.challenge_id}`}
+                                >
+                                  {challenge.challenge_name}
+                                </A>
                               </td>
-                              <td class="text-end py-3 opacity-80">{challenge.total_submissions}</td>
+                              <td class="text-start py-3 opacity-80">{challenge.game_name}</td>
+                              <td class="text-start py-3 opacity-80">{challenge.team_name ?? "-"}</td>
                               <td class="text-center py-3">
                                 <Show
-                                  when={challenge.solved}
+                                  when={challenge.solved_count > 0}
                                   fallback={<span class="text-error">{t("user.submissions.failed")}</span>}
                                 >
                                   <span class="text-success">{t("user.submissions.solved")}</span>
                                 </Show>
+                              </td>
+                              <td class="text-end py-3 opacity-60">
+                                {new Date(challenge.last_submission_at).toLocaleString()}
                               </td>
                             </tr>
                           )}

--- a/web/src/routes/users/[user]/index.tsx
+++ b/web/src/routes/users/[user]/index.tsx
@@ -98,7 +98,7 @@ export default function () {
       yAxis: {
         type: "value",
         min: 0,
-        interval: 1,
+        minInterval: 1,
       },
       series: [
         {

--- a/web/src/routes/users/[user]/index.tsx
+++ b/web/src/routes/users/[user]/index.tsx
@@ -227,7 +227,7 @@ export default function () {
                               <td class="text-start py-3">
                                 <A
                                   class="link-primary hover:underline"
-                                  href={`/games/${challenge.game_id}/challenges/${challenge.challenge_id}`}
+                                  href={`/games/${challenge.game_id}/challenges?challenge=${challenge.challenge_id}`}
                                 >
                                   {challenge.challenge_name}
                                 </A>

--- a/web/src/routes/users/[user]/index.tsx
+++ b/web/src/routes/users/[user]/index.tsx
@@ -1,6 +1,7 @@
 import { handleHttpError } from "@api";
-import { getUser, getUserTeams } from "@api/user";
+import { getUser, getUserSubmissions, getUserTeams, useUserSubmissionStats } from "@api/user";
 import SidebarLayout from "@blocks/sidebar-layout";
+import type { Submission } from "@models/submission";
 import type { Team } from "@models/team";
 import type { User } from "@models/user";
 import { createBreakpoints } from "@solid-primitives/media";
@@ -9,9 +10,12 @@ import { Title } from "@storage/header";
 import { breakpoints, t } from "@storage/theme";
 import Article from "@widgets/article";
 import Button from "@widgets/button";
+import Chart from "@widgets/chart";
 import LoadingTips from "@widgets/loading-tips";
+import Pagination from "@widgets/pagination";
+import Select from "@widgets/select";
 import clsx from "clsx";
-import { createEffect, createSignal, For, Match, Show, Switch, untrack } from "solid-js";
+import { createEffect, createMemo, createResource, createSignal, For, Match, Show, Switch, untrack } from "solid-js";
 import { Transition } from "solid-transition-group";
 import Sidebar from "./_blocks/sidebar";
 
@@ -22,6 +26,13 @@ export default function () {
   const navigate = useNavigate();
   const userId = () => Number.parseInt(params.user ?? "", 10) || null;
   const [teams, setTeams] = createSignal([] as Team[]);
+  const [submissions, setSubmissions] = createSignal([] as Submission[]);
+  const [submissionTotal, setSubmissionTotal] = createSignal(0);
+  const [submissionPage, setSubmissionPage] = createSignal(1);
+  const [selectedGameId, setSelectedGameId] = createSignal<string | null>(null);
+  const [loadingSubmissions, setLoadingSubmissions] = createSignal(false);
+  const pageSize = 10;
+
   createEffect(() => {
     if (!userId()) {
       navigate("/sigtrap/404", { replace: true });
@@ -39,6 +50,129 @@ export default function () {
       setLoading(false);
     });
   });
+
+  const gameOptions = createMemo(() => {
+    const games = new Map<number, string>();
+    for (const team of teams()) {
+      if (team.game_id && team.game_name) {
+        games.set(team.game_id, team.game_name);
+      }
+    }
+    return [
+      { label: t("user.submissions.allGames"), value: "" },
+      ...Array.from(games.entries()).map(([id, name]) => ({
+        label: name,
+        value: id.toString(),
+      })),
+    ];
+  });
+
+  const teamIdToGameId = createMemo(() => {
+    const map = new Map<number, number>();
+    for (const team of teams()) {
+      map.set(team.id, team.game_id);
+    }
+    return map;
+  });
+
+  const gameIdToGameName = createMemo(() => {
+    const map = new Map<number, string>();
+    for (const team of teams()) {
+      if (team.game_name) {
+        map.set(team.game_id, team.game_name);
+      }
+    }
+    return map;
+  });
+
+  const submissionStats = useUserSubmissionStats({
+    id: () => userId()!,
+    game_id: () => {
+      const val = selectedGameId();
+      return val ? Number.parseInt(val, 10) : null;
+    },
+    enabled: () => !!userId(),
+  });
+
+  const chartOption = createMemo(() => {
+    const stats = submissionStats.data;
+    if (!stats || stats.challenges.length === 0) return null;
+    const sortedChallenges = [...stats.challenges].sort((a, b) => b.total_submissions - a.total_submissions);
+    return {
+      grid: {
+        left: "16px",
+        right: "32px",
+        bottom: "32px",
+        top: "16px",
+        containLabel: true,
+      },
+      tooltip: {
+        trigger: "axis",
+        axisPointer: {
+          type: "shadow",
+        },
+      },
+      xAxis: {
+        type: "category",
+        data: sortedChallenges.map((c) => c.challenge_name),
+        axisLabel: {
+          rotate: 30,
+          fontSize: 11,
+        },
+      },
+      yAxis: {
+        type: "value",
+        min: 0,
+        interval: 1,
+      },
+      series: [
+        {
+          name: t("user.submissions.solved"),
+          type: "bar",
+          stack: "total",
+          data: sortedChallenges.map((c) => (c.solved ? 1 : 0)),
+          itemStyle: {
+            color: "#17a750",
+          },
+          barMaxWidth: 48,
+        },
+        {
+          name: t("user.submissions.failed"),
+          type: "bar",
+          stack: "total",
+          data: sortedChallenges.map((c) => c.failed_submissions),
+          itemStyle: {
+            color: "#808080",
+          },
+          barMaxWidth: 48,
+        },
+      ],
+    };
+  });
+
+  createEffect(() => {
+    const uid = userId();
+    const page = submissionPage();
+    const gameId = selectedGameId();
+    if (!uid) return;
+    untrack(async () => {
+      setLoadingSubmissions(true);
+      try {
+        const [data, total] = await getUserSubmissions(
+          uid,
+          page,
+          pageSize,
+          gameId ? Number.parseInt(gameId, 10) : undefined
+        );
+        setSubmissions(data);
+        setSubmissionTotal(total);
+      } catch (err) {
+        handleHttpError(err as Error, t("user.errors.fetchSubmissions.title"));
+      }
+      setLoadingSubmissions(false);
+    });
+  });
+
   const matches = createBreakpoints(breakpoints);
   const [showSidebar, setShowSidebar] = createSignal(false);
 
@@ -52,16 +186,17 @@ export default function () {
               <span class="shrink-0 icon-[fluent--person-20-regular] w-5 h-5" />
               <span>{t("user.description.title")}</span>
             </h3>
-            <section>
+            <section class="max-h-96 overflow-y-auto">
               <Switch>
                 <Match when={loading()}>
                   <LoadingTips />
                 </Match>
                 <Match when={true}>
-                  <Article content={user()?.description || t("user.description.empty")} />
+                  <Article content={user()?.description || t("user.description.empty")} noExtraPaddings compact />
                 </Match>
               </Switch>
             </section>
+            <div class="h-6" />
             <h3 class="h-12 flex items-center border-b border-b-layer-content/15 font-bold space-x-2">
               <span class="shrink-0 icon-[fluent--flag-20-regular] w-5 h-5" />
               <span>{t("user.joinedGames")}</span>
@@ -85,6 +220,112 @@ export default function () {
                 <span class="shrink-0 icon-[fluent--search-sparkle-20-regular] w-5 h-5 text-info" />
                 <span>{t("user.moreJournal")}</span>
               </div>
+            </section>
+            <div class="h-6" />
+            <h3 class="h-12 flex items-center border-b border-b-layer-content/15 font-bold space-x-2">
+              <span class="shrink-0 icon-[fluent--checkmark-20-regular] w-5 h-5" />
+              <span>{t("user.submissions.title")}</span>
+            </h3>
+            <section class="flex flex-col">
+              <div class="flex flex-row items-center py-3">
+                <Select
+                  size="sm"
+                  class="w-64"
+                  items={gameOptions()}
+                  value={selectedGameId() ?? ""}
+                  onValueChange={(e) => {
+                    setSelectedGameId(e.value[0] || null);
+                    setSubmissionPage(1);
+                  }}
+                  placeholder={t("user.submissions.allGames")}
+                />
+              </div>
+              <Show when={chartOption() && !submissionStats.isLoading}>
+                <div class="h-64 py-2">
+                  <Chart option={chartOption()!} />
+                </div>
+              </Show>
+              <Switch>
+                <Match when={loadingSubmissions()}>
+                  <LoadingTips />
+                </Match>
+                <Match when={submissions().length === 0}>
+                  <div class="h-12 flex items-center justify-center opacity-60">
+                    <span>{t("user.submissions.empty")}</span>
+                  </div>
+                </Match>
+                <Match when={true}>
+                  <div class="overflow-x-auto">
+                    <table class="table table-sm w-full">
+                      <thead>
+                        <tr class="border-b border-b-layer-content/15">
+                          <th class="text-start h-10 font-normal opacity-60">{t("user.submissions.challenge")}</th>
+                          <th class="text-start h-10 font-normal opacity-60">{t("user.submissions.game")}</th>
+                          <th class="text-start h-10 font-normal opacity-60">{t("user.submissions.team")}</th>
+                          <th class="text-end h-10 font-normal opacity-60">{t("user.submissions.score")}</th>
+                          <th class="text-center h-10 font-normal opacity-60">{t("user.submissions.status")}</th>
+                          <th class="text-end h-10 font-normal opacity-60">{t("user.submissions.time")}</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <For each={submissions()}>
+                          {(sub) => (
+                            <tr class="border-b border-b-layer-content/10 hover:bg-layer-content/5">
+                              <td class="text-start py-3">
+                                <Show
+                                  when={sub.team_id && teamIdToGameId().has(sub.team_id)}
+                                  fallback={
+                                    <span class="opacity-60">{sub.challenge_name}</span>
+                                  }
+                                >
+                                  <A
+                                    href={`/games/${teamIdToGameId().get(sub.team_id)}/challenges?challenge=${sub.challenge_id}`}
+                                    class="hover:underline"
+                                  >
+                                    {sub.challenge_name}
+                                  </A>
+                                </Show>
+                              </td>
+                              <td class="text-start py-3 opacity-80">
+                                {(sub.team_id && gameIdToGameName().get(teamIdToGameId().get(sub.team_id)!)) ?? "-"}
+                              </td>
+                              <td class="text-start py-3 opacity-80">{sub.team_name ?? "-"}</td>
+                              <td class="text-end py-3">{sub.score ?? "-"}</td>
+                              <td class="text-center py-3">
+                                <Show
+                                  when={sub.solved}
+                                  fallback={
+                                    <span class="text-error">
+                                      {t("user.submissions.failed")}
+                                    </span>
+                                  }
+                                >
+                                  <span class="text-success">
+                                    {t("user.submissions.solved")}
+                                  </span>
+                                </Show>
+                              </td>
+                              <td class="text-end py-3 opacity-60">
+                                {sub.created_at.toFormat("yyyy-MM-dd HH:mm")}
+                              </td>
+                            </tr>
+                          )}
+                        </For>
+                      </tbody>
+                    </table>
+                  </div>
+                  <Show when={submissionTotal() > pageSize}>
+                    <div class="flex justify-center py-4">
+                      <Pagination
+                        count={submissionTotal()}
+                        pageSize={pageSize}
+                        page={submissionPage()}
+                        onPageChange={(p) => setSubmissionPage(p.page)}
+                      />
+                    </div>
+                  </Show>
+                </Match>
+              </Switch>
             </section>
           </div>
         </div>

--- a/web/src/routes/users/[user]/index.tsx
+++ b/web/src/routes/users/[user]/index.tsx
@@ -4,7 +4,7 @@ import SidebarLayout from "@blocks/sidebar-layout";
 import type { Team } from "@models/team";
 import type { User } from "@models/user";
 import { createBreakpoints } from "@solid-primitives/media";
-import { A, useNavigate, useParams } from "@solidjs/router";
+import { A, useNavigate, useParams, useSearchParams } from "@solidjs/router";
 import { Title } from "@storage/header";
 import { breakpoints, t } from "@storage/theme";
 import Article from "@widgets/article";
@@ -22,9 +22,11 @@ export default function () {
   const [loading, setLoading] = createSignal(true);
   const params = useParams();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const userId = () => Number.parseInt(params.user ?? "", 10) || null;
   const [teams, setTeams] = createSignal([] as Team[]);
-  const [selectedGameId, setSelectedGameId] = createSignal<string | null>(null);
+  const [selectedGameId, setSelectedGameId] = createSignal<string | null>((searchParams.game as string) || null);
+  const [allGames, setAllGames] = createSignal(new Map<number, string>());
 
   createEffect(() => {
     if (!userId()) {
@@ -44,12 +46,39 @@ export default function () {
     });
   });
 
+  const submissionStats = useUserSubmissionStats({
+    id: () => userId()!,
+    game_id: () => {
+      const val = selectedGameId();
+      return val ? Number.parseInt(val, 10) : null;
+    },
+    enabled: () => !!userId(),
+  });
+
+  createEffect(() => {
+    const stats = submissionStats.data;
+    if (stats) {
+      setAllGames((prev) => {
+        const next = new Map(prev);
+        for (const stat of stats) {
+          if (stat.game_id && stat.game_name) {
+            next.set(stat.game_id, stat.game_name);
+          }
+        }
+        return next;
+      });
+    }
+  });
+
   const gameOptions = createMemo(() => {
     const games = new Map<number, string>();
     for (const team of teams()) {
       if (team.game_id && team.game_name) {
         games.set(team.game_id, team.game_name);
       }
+    }
+    for (const [id, name] of allGames()) {
+      games.set(id, name);
     }
     return [
       { label: t("user.submissions.allGames"), value: "" },
@@ -58,15 +87,6 @@ export default function () {
         value: id.toString(),
       })),
     ];
-  });
-
-  const submissionStats = useUserSubmissionStats({
-    id: () => userId()!,
-    game_id: () => {
-      const val = selectedGameId();
-      return val ? Number.parseInt(val, 10) : null;
-    },
-    enabled: () => !!userId(),
   });
 
   const chartOption = createMemo(() => {
@@ -135,21 +155,6 @@ export default function () {
         <div class="flex-1 flex flex-col items-center p-3 lg:p-6">
           <div class="flex flex-col w-full max-w-5xl">
             <h3 class="h-12 flex items-center border-b border-b-layer-content/15 font-bold space-x-2">
-              <span class="shrink-0 icon-[fluent--person-20-regular] w-5 h-5" />
-              <span>{t("user.description.title")}</span>
-            </h3>
-            <section class="max-h-96 overflow-y-auto">
-              <Switch>
-                <Match when={loading()}>
-                  <LoadingTips />
-                </Match>
-                <Match when={true}>
-                  <Article content={user()?.description || t("user.description.empty")} noExtraPaddings compact />
-                </Match>
-              </Switch>
-            </section>
-            <div class="h-6" />
-            <h3 class="h-12 flex items-center border-b border-b-layer-content/15 font-bold space-x-2">
               <span class="shrink-0 icon-[fluent--flag-20-regular] w-5 h-5" />
               <span>{t("user.joinedGames")}</span>
             </h3>
@@ -176,21 +181,19 @@ export default function () {
             <div class="h-6" />
             <h3 class="h-12 flex items-center border-b border-b-layer-content/15 font-bold space-x-2">
               <span class="shrink-0 icon-[fluent--checkmark-20-regular] w-5 h-5" />
-              <span>{t("user.submissions.title")}</span>
+              <span class="flex-1">{t("user.submissions.title")}</span>
+              <Select
+                size="sm"
+                class="w-64"
+                items={gameOptions()}
+                value={selectedGameId() ? [selectedGameId()!] : []}
+                onValueChange={(e) => {
+                  setSelectedGameId(e.value[0] || null);
+                }}
+                placeholder={t("user.submissions.allGames")}
+              />
             </h3>
             <section class="flex flex-col">
-              <div class="flex flex-row items-center py-3">
-                <Select
-                  size="sm"
-                  class="w-64"
-                  items={gameOptions()}
-                  value={selectedGameId() ? [selectedGameId()!] : []}
-                  onValueChange={(e) => {
-                    setSelectedGameId(e.value[0] || null);
-                  }}
-                  placeholder={t("user.submissions.allGames")}
-                />
-              </div>
               <Show when={chartOption() && !submissionStats.isLoading}>
                 <div class="h-64 py-2">
                   <Chart option={chartOption()!} />
@@ -248,6 +251,21 @@ export default function () {
                       </tbody>
                     </table>
                   </div>
+                </Match>
+              </Switch>
+            </section>
+            <div class="h-6" />
+            <h3 class="h-12 flex items-center border-b border-b-layer-content/15 font-bold space-x-2">
+              <span class="shrink-0 icon-[fluent--person-20-regular] w-5 h-5" />
+              <span>{t("user.description.title")}</span>
+            </h3>
+            <section class="max-h-96 overflow-y-auto">
+              <Switch>
+                <Match when={loading()}>
+                  <LoadingTips />
+                </Match>
+                <Match when={true}>
+                  <Article content={user()?.description || t("user.description.empty")} noExtraPaddings compact />
                 </Match>
               </Switch>
             </section>

--- a/web/src/routes/users/[user]/index.tsx
+++ b/web/src/routes/users/[user]/index.tsx
@@ -240,7 +240,7 @@ export default function () {
                                 </Show>
                               </td>
                               <td class="text-end py-3 opacity-60">
-                                {new Date(challenge.last_submission_at).toLocaleString()}
+                                {challenge.last_submission_at.toFormat("yyyy-MM-dd HH:mm:ss")}
                               </td>
                             </tr>
                           )}

--- a/web/src/routes/users/[user]/index.tsx
+++ b/web/src/routes/users/[user]/index.tsx
@@ -1,7 +1,6 @@
 import { handleHttpError } from "@api";
-import { getUser, getUserSubmissions, getUserTeams, useUserSubmissionStats } from "@api/user";
+import { getUser, getUserTeams, useUserSubmissionStats, useUserSubmissions } from "@api/user";
 import SidebarLayout from "@blocks/sidebar-layout";
-import type { Submission } from "@models/submission";
 import type { Team } from "@models/team";
 import type { User } from "@models/user";
 import { createBreakpoints } from "@solid-primitives/media";
@@ -15,7 +14,7 @@ import LoadingTips from "@widgets/loading-tips";
 import Pagination from "@widgets/pagination";
 import Select from "@widgets/select";
 import clsx from "clsx";
-import { createEffect, createMemo, createResource, createSignal, For, Match, Show, Switch, untrack } from "solid-js";
+import { createEffect, createMemo, createSignal, For, Match, Show, Switch, untrack } from "solid-js";
 import { Transition } from "solid-transition-group";
 import Sidebar from "./_blocks/sidebar";
 
@@ -26,11 +25,8 @@ export default function () {
   const navigate = useNavigate();
   const userId = () => Number.parseInt(params.user ?? "", 10) || null;
   const [teams, setTeams] = createSignal([] as Team[]);
-  const [submissions, setSubmissions] = createSignal([] as Submission[]);
-  const [submissionTotal, setSubmissionTotal] = createSignal(0);
   const [submissionPage, setSubmissionPage] = createSignal(1);
   const [selectedGameId, setSelectedGameId] = createSignal<string | null>(null);
-  const [loadingSubmissions, setLoadingSubmissions] = createSignal(false);
   const pageSize = 10;
 
   createEffect(() => {
@@ -94,6 +90,17 @@ export default function () {
     enabled: () => !!userId(),
   });
 
+  const submissionsQuery = useUserSubmissions({
+    id: () => userId()!,
+    page: () => submissionPage(),
+    page_size: () => pageSize,
+    game_id: () => {
+      const val = selectedGameId();
+      return val ? Number.parseInt(val, 10) : null;
+    },
+    enabled: () => !!userId(),
+  });
+
   const chartOption = createMemo(() => {
     const stats = submissionStats.data;
     if (!stats || stats.challenges.length === 0) return null;
@@ -148,29 +155,6 @@ export default function () {
         },
       ],
     };
-  });
-
-  createEffect(() => {
-    const uid = userId();
-    const page = submissionPage();
-    const gameId = selectedGameId();
-    if (!uid) return;
-    untrack(async () => {
-      setLoadingSubmissions(true);
-      try {
-        const [data, total] = await getUserSubmissions(
-          uid,
-          page,
-          pageSize,
-          gameId ? Number.parseInt(gameId, 10) : undefined
-        );
-        setSubmissions(data);
-        setSubmissionTotal(total);
-      } catch (err) {
-        handleHttpError(err as Error, t("user.errors.fetchSubmissions.title"));
-      }
-      setLoadingSubmissions(false);
-    });
   });
 
   const matches = createBreakpoints(breakpoints);
@@ -232,7 +216,7 @@ export default function () {
                   size="sm"
                   class="w-64"
                   items={gameOptions()}
-                  value={selectedGameId() ?? ""}
+                  value={selectedGameId() ? [selectedGameId()!] : []}
                   onValueChange={(e) => {
                     setSelectedGameId(e.value[0] || null);
                     setSubmissionPage(1);
@@ -246,10 +230,10 @@ export default function () {
                 </div>
               </Show>
               <Switch>
-                <Match when={loadingSubmissions()}>
+                <Match when={submissionsQuery.isLoading}>
                   <LoadingTips />
                 </Match>
-                <Match when={submissions().length === 0}>
+                <Match when={!submissionsQuery.data || submissionsQuery.data[0].length === 0}>
                   <div class="h-12 flex items-center justify-center opacity-60">
                     <span>{t("user.submissions.empty")}</span>
                   </div>
@@ -268,15 +252,13 @@ export default function () {
                         </tr>
                       </thead>
                       <tbody>
-                        <For each={submissions()}>
+                        <For each={submissionsQuery.data[0]}>
                           {(sub) => (
                             <tr class="border-b border-b-layer-content/10 hover:bg-layer-content/5">
                               <td class="text-start py-3">
                                 <Show
                                   when={sub.team_id && teamIdToGameId().has(sub.team_id)}
-                                  fallback={
-                                    <span class="opacity-60">{sub.challenge_name}</span>
-                                  }
+                                  fallback={<span class="opacity-60">{sub.challenge_name}</span>}
                                 >
                                   <A
                                     href={`/games/${teamIdToGameId().get(sub.team_id)}/challenges?challenge=${sub.challenge_id}`}
@@ -294,30 +276,22 @@ export default function () {
                               <td class="text-center py-3">
                                 <Show
                                   when={sub.solved}
-                                  fallback={
-                                    <span class="text-error">
-                                      {t("user.submissions.failed")}
-                                    </span>
-                                  }
+                                  fallback={<span class="text-error">{t("user.submissions.failed")}</span>}
                                 >
-                                  <span class="text-success">
-                                    {t("user.submissions.solved")}
-                                  </span>
+                                  <span class="text-success">{t("user.submissions.solved")}</span>
                                 </Show>
                               </td>
-                              <td class="text-end py-3 opacity-60">
-                                {sub.created_at.toFormat("yyyy-MM-dd HH:mm")}
-                              </td>
+                              <td class="text-end py-3 opacity-60">{sub.created_at.toFormat("yyyy-MM-dd HH:mm")}</td>
                             </tr>
                           )}
                         </For>
                       </tbody>
                     </table>
                   </div>
-                  <Show when={submissionTotal() > pageSize}>
+                  <Show when={submissionsQuery.data && submissionsQuery.data[1] > pageSize}>
                     <div class="flex justify-center py-4">
                       <Pagination
-                        count={submissionTotal()}
+                        count={submissionsQuery.data![1]}
                         pageSize={pageSize}
                         page={submissionPage()}
                         onPageChange={(p) => setSubmissionPage(p.page)}

--- a/web/src/routes/users/[user]/index.tsx
+++ b/web/src/routes/users/[user]/index.tsx
@@ -1,5 +1,5 @@
 import { handleHttpError } from "@api";
-import { getUser, getUserTeams, useUserSubmissionStats, useUserSubmissions } from "@api/user";
+import { getUser, getUserTeams, useUserSubmissionStats } from "@api/user";
 import SidebarLayout from "@blocks/sidebar-layout";
 import type { Team } from "@models/team";
 import type { User } from "@models/user";
@@ -11,7 +11,6 @@ import Article from "@widgets/article";
 import Button from "@widgets/button";
 import Chart from "@widgets/chart";
 import LoadingTips from "@widgets/loading-tips";
-import Pagination from "@widgets/pagination";
 import Select from "@widgets/select";
 import clsx from "clsx";
 import { createEffect, createMemo, createSignal, For, Match, Show, Switch, untrack } from "solid-js";
@@ -25,9 +24,7 @@ export default function () {
   const navigate = useNavigate();
   const userId = () => Number.parseInt(params.user ?? "", 10) || null;
   const [teams, setTeams] = createSignal([] as Team[]);
-  const [submissionPage, setSubmissionPage] = createSignal(1);
   const [selectedGameId, setSelectedGameId] = createSignal<string | null>(null);
-  const pageSize = 10;
 
   createEffect(() => {
     if (!userId()) {
@@ -63,37 +60,8 @@ export default function () {
     ];
   });
 
-  const teamIdToGameId = createMemo(() => {
-    const map = new Map<number, number>();
-    for (const team of teams()) {
-      map.set(team.id, team.game_id);
-    }
-    return map;
-  });
-
-  const gameIdToGameName = createMemo(() => {
-    const map = new Map<number, string>();
-    for (const team of teams()) {
-      if (team.game_name) {
-        map.set(team.game_id, team.game_name);
-      }
-    }
-    return map;
-  });
-
   const submissionStats = useUserSubmissionStats({
     id: () => userId()!,
-    game_id: () => {
-      const val = selectedGameId();
-      return val ? Number.parseInt(val, 10) : null;
-    },
-    enabled: () => !!userId(),
-  });
-
-  const submissionsQuery = useUserSubmissions({
-    id: () => userId()!,
-    page: () => submissionPage(),
-    page_size: () => pageSize,
     game_id: () => {
       const val = selectedGameId();
       return val ? Number.parseInt(val, 10) : null;
@@ -219,7 +187,6 @@ export default function () {
                   value={selectedGameId() ? [selectedGameId()!] : []}
                   onValueChange={(e) => {
                     setSelectedGameId(e.value[0] || null);
-                    setSubmissionPage(1);
                   }}
                   placeholder={t("user.submissions.allGames")}
                 />
@@ -230,10 +197,10 @@ export default function () {
                 </div>
               </Show>
               <Switch>
-                <Match when={submissionsQuery.isLoading}>
+                <Match when={submissionStats.isLoading}>
                   <LoadingTips />
                 </Match>
-                <Match when={!submissionsQuery.data || submissionsQuery.data[0].length === 0}>
+                <Match when={!submissionStats.data || submissionStats.data.challenges.length === 0}>
                   <div class="h-12 flex items-center justify-center opacity-60">
                     <span>{t("user.submissions.empty")}</span>
                   </div>
@@ -244,60 +211,32 @@ export default function () {
                       <thead>
                         <tr class="border-b border-b-layer-content/15">
                           <th class="text-start h-10 font-normal opacity-60">{t("user.submissions.challenge")}</th>
-                          <th class="text-start h-10 font-normal opacity-60">{t("user.submissions.game")}</th>
-                          <th class="text-start h-10 font-normal opacity-60">{t("user.submissions.team")}</th>
-                          <th class="text-end h-10 font-normal opacity-60">{t("user.submissions.score")}</th>
+                          <th class="text-end h-10 font-normal opacity-60">{t("user.submissions.submissions")}</th>
                           <th class="text-center h-10 font-normal opacity-60">{t("user.submissions.status")}</th>
-                          <th class="text-end h-10 font-normal opacity-60">{t("user.submissions.time")}</th>
                         </tr>
                       </thead>
                       <tbody>
-                        <For each={submissionsQuery.data[0]}>
-                          {(sub) => (
+                        <For each={submissionStats.data!.challenges}>
+                          {(challenge) => (
                             <tr class="border-b border-b-layer-content/10 hover:bg-layer-content/5">
                               <td class="text-start py-3">
-                                <Show
-                                  when={sub.team_id && teamIdToGameId().has(sub.team_id)}
-                                  fallback={<span class="opacity-60">{sub.challenge_name}</span>}
-                                >
-                                  <A
-                                    href={`/games/${teamIdToGameId().get(sub.team_id)}/challenges?challenge=${sub.challenge_id}`}
-                                    class="hover:underline"
-                                  >
-                                    {sub.challenge_name}
-                                  </A>
-                                </Show>
+                                <span class="opacity-60">{challenge.challenge_name}</span>
                               </td>
-                              <td class="text-start py-3 opacity-80">
-                                {(sub.team_id && gameIdToGameName().get(teamIdToGameId().get(sub.team_id)!)) ?? "-"}
-                              </td>
-                              <td class="text-start py-3 opacity-80">{sub.team_name ?? "-"}</td>
-                              <td class="text-end py-3">{sub.score ?? "-"}</td>
+                              <td class="text-end py-3 opacity-80">{challenge.total_submissions}</td>
                               <td class="text-center py-3">
                                 <Show
-                                  when={sub.solved}
+                                  when={challenge.solved}
                                   fallback={<span class="text-error">{t("user.submissions.failed")}</span>}
                                 >
                                   <span class="text-success">{t("user.submissions.solved")}</span>
                                 </Show>
                               </td>
-                              <td class="text-end py-3 opacity-60">{sub.created_at.toFormat("yyyy-MM-dd HH:mm")}</td>
                             </tr>
                           )}
                         </For>
                       </tbody>
                     </table>
                   </div>
-                  <Show when={submissionsQuery.data && submissionsQuery.data[1] > pageSize}>
-                    <div class="flex justify-center py-4">
-                      <Pagination
-                        count={submissionsQuery.data![1]}
-                        pageSize={pageSize}
-                        page={submissionPage()}
-                        onPageChange={(p) => setSubmissionPage(p.page)}
-                      />
-                    </div>
-                  </Show>
                 </Match>
               </Switch>
             </section>


### PR DESCRIPTION
- Backend: UserChallengeStats now includes game_id, game_name, team_name, last_submission_at
- Backend: removed ChallengeStats/SubmissionStats structs, handler returns Vec<UserChallengeStats> directly
- Backend: removed team filters to include training (练习场) submissions in stats
- Backend: all data reshaping moved to frontend (solved/failed computed from raw solved_count/total_submissions)
- Frontend: challenge names are now clickable links to /games/:id/challenges/:id
- Frontend: table shows game, team, and submission time columns
- Frontend: stats data flattened (ChallengeStats[] instead of SubmissionStats wrapper)
- Frontend: description section moved below submission records
- Frontend: game filter Select moved inline into h3 header
- Frontend: gameOptions accumulates games from all stat fetches (supports training submissions)
- Frontend: profile page reads ?game= query param to pre-select game when navigating from game context
- Frontend: titlebar avatar and team member links pass game_id as query param
- Fix: last_submission_at uses Luxon DateTime with .toFormat() instead of new Date()
- i18n: added game/team/time keys to all four locales, renamed time to submission time