### PR TITLE
:bug: fallback to default email templates when subject or body is empty

### DIFF
--- a/crates/server/src/routes/account/mod.rs
+++ b/crates/server/src/routes/account/mod.rs
@@ -393,18 +393,22 @@ async fn send_email(
   let verify_email_subject = email_config
     .verify_email_subject
     .clone()
+    .filter(|s| !s.trim().is_empty())
     .unwrap_or("Verify your account - Ret2Shell".to_owned());
   let reset_password_subject = email_config
     .reset_password_email_subject
     .clone()
+    .filter(|s| !s.trim().is_empty())
     .unwrap_or("Reset your password - Ret2Shell".to_owned());
   let verify_email_body = email_config
     .verify_email_body
     .clone()
+    .filter(|s| !s.trim().is_empty())
     .unwrap_or(include_str!("./verify-email.html").to_owned());
   let reset_password_body = email_config
     .reset_password_email_body
     .clone()
+    .filter(|s| !s.trim().is_empty())
     .unwrap_or(include_str!("./reset-password.html").to_owned());
   let (subject, body) = match email_type {
     EmailType::Verify => (verify_email_subject, verify_email_body),


### PR DESCRIPTION
## Summary

Fix the issue where the built-in default email templates are ignored when the email subject/body config is an empty string or contains only whitespace.

## Changes

- In `crates/server/src/routes/account/mod.rs`, added `.filter(|s| !s.trim().is_empty())` before `unwrap_or` for all four email template fields (verify/reset subject and body).

This ensures that `None`, `""`, and whitespace-only values all fall back to the default built-in templates.

## Testing

- Ran `cargo fmt`.
- Verified the diff only touches the intended file.