### PR TITLE
:sparkles: support privileged securityContext for challenge env

### DIFF
--- a/crates/cluster/src/manager.rs
+++ b/crates/cluster/src/manager.rs
@@ -527,12 +527,17 @@ impl Cluster {
     } else {
       None
     };
-    let security_context = SecurityContext {
+    let privileged = env_config.privileged.is_some_and(|p| p);
+    let restricted_security_context = SecurityContext {
       allow_privilege_escalation: Some(false),
       capabilities: Some(Capabilities {
         drop: Some(vec!["NET_BIND_SERVICE".to_owned()]),
         ..Default::default()
       }),
+      ..Default::default()
+    };
+    let privileged_security_context = SecurityContext {
+      privileged: Some(true),
       ..Default::default()
     };
     let pod_security_context = PodSecurityContext {
@@ -551,9 +556,7 @@ impl Cluster {
       },
       spec: Some(PodSpec {
         enable_service_links: Some(false),
-        security_context: env_config
-          .restricted
-          .is_some_and(|r| r)
+        security_context: (!privileged && env_config.restricted.is_some_and(|r| r))
           .then_some(pod_security_context),
         image_pull_secrets: env_config
           .pull_secret
@@ -614,10 +617,14 @@ impl Cluster {
               ),
               ..Default::default()
             }),
-            security_context: image
-              .restricted
-              .is_some_and(|r| r)
-              .then(|| security_context.clone()),
+            security_context: if privileged {
+              Some(privileged_security_context.clone())
+            } else {
+              image
+                .restricted
+                .is_some_and(|r| r)
+                .then(|| restricted_security_context.clone())
+            },
             ..Default::default()
           })
           .collect(),

--- a/crates/config/src/cluster.rs
+++ b/crates/config/src/cluster.rs
@@ -131,6 +131,7 @@ fn default_storage_req() -> Option<String> {
 pub struct ChallengeEnv {
   pub internet: bool,
   pub restricted: Option<bool>,
+  pub privileged: Option<bool>,
   pub images: Vec<ChallengeImage>,
   pub pull_secret: Option<String>,
 }
@@ -155,6 +156,7 @@ impl ChallengeEnv {
     Self {
       internet: false,
       restricted: None,
+      privileged: None,
       images: self.images.into_iter().map(|i| i.desensitize()).collect(),
       pull_secret: None,
     }
@@ -263,6 +265,7 @@ mod tests {
     let desensitized = ChallengeEnv {
       internet: true,
       restricted: Some(true),
+      privileged: Some(true),
       images: vec![image("web")],
       pull_secret: Some("registry-secret".to_owned()),
     }
@@ -270,6 +273,7 @@ mod tests {
 
     assert!(!desensitized.internet);
     assert_eq!(desensitized.restricted, None);
+    assert_eq!(desensitized.privileged, None);
     assert_eq!(desensitized.pull_secret, None);
     assert_eq!(desensitized.images.len(), 1);
     assert_eq!(desensitized.images[0].tag, "ret.sh.cn/shadowed:latest");

--- a/crates/server/src/routes/game/repo_sync.rs
+++ b/crates/server/src/routes/game/repo_sync.rs
@@ -896,6 +896,7 @@ mod tests {
     ChallengeEnv {
       internet: true,
       restricted: Some(false),
+      privileged: Some(false),
       images,
       pull_secret: Some("registry-secret".to_owned()),
     }

--- a/web/src/lib/blocks/challenge/instances.tsx
+++ b/web/src/lib/blocks/challenge/instances.tsx
@@ -118,6 +118,7 @@ function CreateForm(fnProps: { gameId: number; challengeId: number; onDone?: () 
           env: {
             internet: challengeEnv.data?.internet || false,
             restricted: challengeEnv.data?.restricted ?? null,
+            privileged: challengeEnv.data?.privileged ?? null,
             images: [...(challengeEnv.data?.images || []), sanitizeChallengeImage(form)],
             pull_secret: challengeEnv.data?.pull_secret || null,
           },
@@ -655,6 +656,7 @@ export default function (props: ChallengeWidgetProps) {
       env: {
         internet: !(challengeEnv.data?.internet || false),
         restricted: challengeEnv.data?.restricted ?? null,
+        privileged: challengeEnv.data?.privileged ?? null,
         images: challengeEnv.data?.images || [],
         pull_secret: challengeEnv.data?.pull_secret || null,
       },
@@ -667,6 +669,20 @@ export default function (props: ChallengeWidgetProps) {
       env: {
         internet: challengeEnv.data?.internet || false,
         restricted: !(challengeEnv.data?.restricted ?? false),
+        privileged: challengeEnv.data?.privileged ?? null,
+        images: challengeEnv.data?.images || [],
+        pull_secret: challengeEnv.data?.pull_secret || null,
+      },
+    });
+  }
+  async function onTogglePrivileged() {
+    updateMutation.mutate({
+      game_id: challenge.data!.game_id,
+      challenge_id: challenge.data!.id,
+      env: {
+        internet: challengeEnv.data?.internet || false,
+        restricted: challengeEnv.data?.restricted ?? null,
+        privileged: !(challengeEnv.data?.privileged ?? false),
         images: challengeEnv.data?.images || [],
         pull_secret: challengeEnv.data?.pull_secret || null,
       },
@@ -680,6 +696,7 @@ export default function (props: ChallengeWidgetProps) {
       env: {
         internet: challengeEnv.data?.internet || false,
         restricted: challengeEnv.data?.restricted ?? null,
+        privileged: challengeEnv.data?.privileged ?? null,
         images: challengeEnv.data?.images?.filter((image) => image.name !== name) || [],
         pull_secret: challengeEnv.data?.pull_secret || null,
       },
@@ -705,6 +722,7 @@ export default function (props: ChallengeWidgetProps) {
       env: {
         internet: challengeEnv.data?.internet || false,
         restricted: challengeEnv.data?.restricted ?? null,
+        privileged: challengeEnv.data?.privileged ?? null,
         images: challengeEnv.data?.images || [],
         pull_secret: n ?? null,
       },
@@ -789,6 +807,15 @@ export default function (props: ChallengeWidgetProps) {
           }}
         >
           <span class="flex-1 text-start">{t("challenge.instance.restrict")}</span>
+        </Checkbox>
+        <Checkbox
+          checked={challengeEnv.data?.privileged ?? false}
+          onChange={() => {
+            onTogglePrivileged();
+          }}
+        >
+          <span class="shrink-0 icon-[fluent--shield-20-regular] w-5 h-5" />
+          <span class="flex-1 text-start">{t("challenge.instance.privileged")}</span>
         </Checkbox>
         <Input
           class="flex-1"

--- a/web/src/lib/i18n/en-us.json
+++ b/web/src/lib/i18n/en-us.json
@@ -1171,6 +1171,7 @@
       "delete": "After deleting the instance configuration, the challenge will revert to an attachment-based challenge.",
       "internet": "Allow Internet access",
       "restrict": "Restrict root privileges",
+      "privileged": "Run as privileged",
       "registrySecret": "Registry secret (must be configured in cluster)",
       "runningContainers": "Running instances",
       "status": {

--- a/web/src/lib/i18n/ja-jp.json
+++ b/web/src/lib/i18n/ja-jp.json
@@ -1171,6 +1171,7 @@
       "delete": "環境設定を削除すると、問題は添付ファイル形式の問題に戻ります。",
       "internet": "コンテナ内からインターネットへのアクセスを許可する",
       "restrict": "Root権限の制限",
+      "privileged": "特権で実行",
       "registrySecret": "リポジトリシークレット（事前にリソースを構成する必要があります）",
       "runningContainers": "実行中の環境",
       "status": {

--- a/web/src/lib/i18n/zh-cn.json
+++ b/web/src/lib/i18n/zh-cn.json
@@ -1171,6 +1171,7 @@
       "delete": "删除环境配置后，题目将变回附件类题目。",
       "internet": "允许容器内访问互联网",
       "restrict": "限制 Root 权限",
+      "privileged": "以特权运行",
       "registrySecret": "仓库密钥（需预先配置资源）",
       "runningContainers": "运行中的环境",
       "status": {

--- a/web/src/lib/i18n/zh-tw.json
+++ b/web/src/lib/i18n/zh-tw.json
@@ -1171,6 +1171,7 @@
       "delete": "刪除環境配置後，題目將變回附件類題目。",
       "internet": "允許容器內訪問互聯網",
       "restrict": "限制 Root 權限",
+      "privileged": "以特權執行",
       "registrySecret": "倉庫密鑰（需預先配置資源）",
       "runningContainers": "運行中的環境",
       "status": {

--- a/web/src/lib/models/challenge.ts
+++ b/web/src/lib/models/challenge.ts
@@ -35,6 +35,7 @@ export type ChallengeImage = {
 export type ChallengeEnv = {
   internet: boolean;
   restricted: boolean | null;
+  privileged: boolean | null;
   images: ChallengeImage[];
   pull_secret: string | null;
 };


### PR DESCRIPTION
## Summary

Add support for setting `securityContext.privileged: true` on challenge env pods.

### Backend
- `crates/config/src/cluster.rs`: add `privileged: Option<bool>` to `ChallengeEnv`; redact it in `desensitize()`.
- `crates/cluster/src/manager.rs`: when `privileged` is enabled, set container `SecurityContext.privileged: true` and skip the restricted pod/container security context.
- `crates/server/src/routes/game/repo_sync.rs`: update test helper to include the new field.

### Frontend
- `web/src/lib/models/challenge.ts`: add `privileged` to `ChallengeEnv` type.
- `web/src/lib/blocks/challenge/instances.tsx`: add a privileged toggle next to the existing env-level toggles, using a shield icon.
- `web/src/lib/i18n/*`: add translations for the new toggle.

### Testing
- `cargo +nightly fmt`, `cargo check`, `cargo clippy --all-targets`
- `cargo test -p r2s-config`
- `cargo test -p r2s-server --lib routes::game::repo_sync::tests`
- `pnpm -C web format`, `pnpm -C web lint`, `pnpm -C web test`, `pnpm -C web build:dev`

All passed.
