### PR TITLE
:sparkles: support extended team query by token

### DIFF
--- a/crates/server/src/routes/game/team/mod.rs
+++ b/crates/server/src/routes/game/team/mod.rs
@@ -591,6 +591,7 @@ async fn delete_team_extra(
 #[derive(Deserialize)]
 struct TeamTokenQuery {
   pub token: String,
+  pub ex: Option<bool>,
 }
 
 async fn query_team_by_token(
@@ -600,5 +601,12 @@ async fn query_team_by_token(
   let team = team::get_by_token(&db.conn, game.id, &query.token)
     .await?
     .ok_or_else(|| ResponseError::NotFound("team not found".to_owned()))?;
-  Ok(Json(team))
+  let result = if query.ex.unwrap_or(false) {
+    team::get_ex(&db.conn, team.id)
+      .await?
+      .ok_or(ResponseError::NotFound("team not found".to_string()))?
+  } else {
+    team.into()
+  };
+  Ok(Json(result))
 }


### PR DESCRIPTION
为 `GET /game/:game_id/team/query?token=` 增加 `ex` 查询参数：\n- 默认返回基础 team 信息\n- `?ex=true` 时返回包含 game_name / institute_name 的扩展信息\n\n测试：\n- `cargo +nightly fmt`\n- `cargo clippy --all-targets --all-features`\n- `cargo test`\n- `pnpm -C web lint` / `pnpm -C web format`