### PR TITLE
:bug: fetch full challenge list when pagination is not requested

### DIFF
--- a/web/src/lib/api/challenge.ts
+++ b/web/src/lib/api/challenge.ts
@@ -43,12 +43,12 @@ export function useChallenges({
   enabled?: () => boolean;
   onError?: (err: Error) => boolean;
 }) {
-  const keys = createMemo(() => ["game", game_id(), "challenge", "list", page?.() ?? 1, page_size?.() ?? 200]);
+  const keys = createMemo(() => ["game", game_id(), "challenge", "list", page?.() ?? "all", page_size?.() ?? "all"]);
   // console.log(keys());
   return useQuery(
     () => ({
       queryKey: keys(),
-      queryFn: async () => await getChallengeList(game_id(), page?.() ?? 1, page_size?.() ?? 200),
+      queryFn: async () => await getChallengeList(game_id(), page?.(), page_size?.()),
       enabled: enabled?.(),
       throwOnError: (err: Error) => {
         handleHttpError(err, t("challenge.errors.fetchList.title"));


### PR DESCRIPTION
Fix challenge list truncation when a game has more than 100 challenges.

The frontend previously called `useChallenges()` with default pagination values
`page=1&page_size=200`. The backend clamps `page_size` to `MAX_PAGE_SIZE = 100`,
so the challenge sidebar only received the first 100 challenges.

This change avoids sending pagination parameters when callers do not explicitly
request pagination. The backend already supports returning the full challenge
list when `page` or `page_size` is omitted.