### PR TITLE
:sparkles: support separate challenge clusters in the Helm chart

### DIFF
--- a/deploy/helm/ret2shell/templates/_config.tpl
+++ b/deploy/helm/ret2shell/templates/_config.tpl
@@ -158,8 +158,11 @@ validator = {{ .Values.platform.config.captcha.validator | quote }}
 
 [cluster]
 enabled = {{ .Values.platform.config.cluster.enabled }}
-try_default = true
+try_default = {{ .Values.platform.config.cluster.tryDefault }}
 auto_infer = false
+{{- if .Values.platform.config.cluster.kubeConfigPath }}
+kube_config_path = {{ .Values.platform.config.cluster.kubeConfigPath | quote }}
+{{- end }}
 node_selector = {{ .Values.platform.config.cluster.nodeSelector | quote }}
 enable_capture = {{ .Values.platform.config.cluster.enableCapture }}
 capture_directory = '/var/lib/ret2shell/captures'

--- a/deploy/helm/ret2shell/templates/platform.yaml
+++ b/deploy/helm/ret2shell/templates/platform.yaml
@@ -205,6 +205,9 @@ spec:
               mountPath: /etc/ret2shell/blocked.txt
               subPath: blocked.txt
               readOnly: true
+          {{- with .Values.platform.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.platform.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -224,6 +227,9 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
+      {{- with .Values.platform.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.platform.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/ret2shell/values.schema.json
+++ b/deploy/helm/ret2shell/values.schema.json
@@ -52,6 +52,28 @@
               }
             }
           }
+        },
+        "extraVolumes": {
+          "type": "array"
+        },
+        "extraVolumeMounts": {
+          "type": "array"
+        },
+        "config": {
+          "type": "object",
+          "properties": {
+            "cluster": {
+              "type": "object",
+              "properties": {
+                "tryDefault": {
+                  "type": "boolean"
+                },
+                "kubeConfigPath": {
+                  "type": "string"
+                }
+              }
+            }
+          }
         }
       },
       "allOf": [
@@ -104,6 +126,43 @@
                   }
                 },
                 "required": ["hosts"]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "config": {
+                "properties": {
+                  "cluster": {
+                    "properties": {
+                      "tryDefault": {
+                        "const": false
+                      }
+                    },
+                    "required": ["tryDefault"]
+                  }
+                },
+                "required": ["cluster"]
+              }
+            },
+            "required": ["config"]
+          },
+          "then": {
+            "properties": {
+              "config": {
+                "properties": {
+                  "cluster": {
+                    "properties": {
+                      "kubeConfigPath": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": ["kubeConfigPath"]
+                  }
+                }
               }
             }
           }

--- a/deploy/helm/ret2shell/values.yaml
+++ b/deploy/helm/ret2shell/values.yaml
@@ -22,6 +22,8 @@ platform:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  extraVolumes: []
+  extraVolumeMounts: []
   serviceAccount:
     create: true
     name: ""
@@ -77,6 +79,10 @@ platform:
       level: info,tower_http=info,sqlx=warn
     cluster:
       enabled: true
+      # tryDefault=true: use the in-cluster service account (same cluster as the platform pod)
+      # tryDefault=false: use kubeConfigPath to point at an explicit kubeconfig for a separate cluster
+      tryDefault: true
+      kubeConfigPath: ""
       nodeSelector: ""
       traffic: ""
       lifecycle: ""


### PR DESCRIPTION
## Summary

- Expose platform cluster settings through Helm values (`platform.config.cluster`).
- Support mounting an explicit kubeconfig for challenge workloads on a separate cluster.
- Keep the default single-cluster path on in-cluster credentials.

## Why

Production setups often run the platform and challenge sandboxes on different Kubernetes clusters; the chart previously had no first-class way to wire that.

## Testing

- [x] `helm template` with default values still uses in-cluster config
- [x] `helm template` with `kubeConfigPath` / cluster values renders the expected volume mounts and config
- [x] Schema rejects invalid cluster config shapes