### PR TITLE
:sparkles: add clusterIP platform exposure mode to the Helm chart

### DIFF
--- a/deploy/helm/ret2shell/README.md
+++ b/deploy/helm/ret2shell/README.md
@@ -30,7 +30,7 @@ helm install ret2shell ./deploy/helm/ret2shell -n ret2shell-platform --create-na
 
 Useful switches:
 
-- `platform.exposure.type=ingress|nodePort`
+- `platform.exposure.type=ingress|nodePort|clusterIP`
 - `postgresql.mode=internal|external`
 - `valkey.mode=internal|external`
 - `valkey.architecture=standalone|replication`
@@ -65,6 +65,7 @@ Example renders:
 ```bash
 helm template ret2shell ./deploy/helm/ret2shell -n ret2shell-platform -f ./deploy/helm/ret2shell/examples/values-ingress-internal.yaml
 helm template ret2shell ./deploy/helm/ret2shell -n ret2shell-platform -f ./deploy/helm/ret2shell/examples/values-nodeport-external.yaml
+helm template ret2shell ./deploy/helm/ret2shell -n ret2shell-platform -f ./deploy/helm/ret2shell/examples/values-clusterip-internal.yaml
 ```
 
 The chart defaults are templateable for validation, but you should replace at least these values before production use:

--- a/deploy/helm/ret2shell/examples/values-clusterip-external.yaml
+++ b/deploy/helm/ret2shell/examples/values-clusterip-external.yaml
@@ -1,0 +1,36 @@
+platform:
+  exposure:
+    type: clusterIP
+  config:
+    server:
+      # Public hostname served by your Gateway / HTTPRoute.
+      externalDomain: ctf.example.com
+
+postgresql:
+  mode: external
+  external:
+    host: postgresql.example.com
+    port: 5432
+    database: ret2shell
+    username: ret2shell
+    password: replace-me
+    sslMode: disable
+
+valkey:
+  mode: external
+  external:
+    url: redis://:replace-me@valkey.example.com:6379/0
+
+nats:
+  mode: external
+  external:
+    host: nats.example.com
+    port: 4222
+    token: replace-me
+    tls: false
+
+registry:
+  mode: disabled
+
+victoriaLogs:
+  mode: disabled

--- a/deploy/helm/ret2shell/examples/values-clusterip-internal.yaml
+++ b/deploy/helm/ret2shell/examples/values-clusterip-internal.yaml
@@ -1,0 +1,13 @@
+platform:
+  exposure:
+    type: clusterIP
+  config:
+    server:
+      # Public hostname served by your Gateway / HTTPRoute.
+      externalDomain: ctf.example.com
+
+registry:
+  mode: internal
+  externalAccess:
+    # Registry still needs a node-reachable or separately routed address.
+    host: registry.example.com:30310

--- a/deploy/helm/ret2shell/values.schema.json
+++ b/deploy/helm/ret2shell/values.schema.json
@@ -14,7 +14,7 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["ingress", "nodePort"]
+              "enum": ["ingress", "nodePort", "clusterIP"]
             }
           }
         },


### PR DESCRIPTION
## Summary

- Allow `platform.exposure.type=clusterIP` so the chart keeps only the existing ClusterIP Service and does not create chart-managed NodePort or Ingress resources.
- This is meant for Gateway API / HTTPRoute (or other in-cluster ingress) setups that route to the platform Service directly.
- Document the mode in README, allow it in `values.schema.json`, and add example values for internal and external dependency layouts.

## Why

Admins who terminate TLS / routing outside the chart (e.g. HTTPRoute → ClusterIP Service) previously had to choose `ingress` or `nodePort`, which creates resources they do not need. `clusterIP` makes that deployment path explicit and valid.

Template behavior already skips NodePort/Ingress unless those modes are selected; this change mainly formalizes the enum and operator guidance. That's why no template is modified in this PR.

## Testing

- [x] `helm template` with `examples/values-clusterip-internal.yaml` — renders ClusterIP Service only; no NodePort Service / Ingress
- [x] `helm template` with `examples/values-clusterip-external.yaml` — same exposure behavior with external deps
- [x] `helm template` with existing `values-ingress-internal.yaml` / `values-nodeport-external.yaml` — unchanged
- [x] Confirm schema accepts `clusterIP` and rejects unknown exposure types