### PR TITLE
:bug: implement Rune return parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4086,6 +4086,7 @@ dependencies = [
  "rune",
  "rune-modules",
  "serde",
+ "serde_json",
  "thiserror 2.0.19",
  "tokio",
  "tracing",

--- a/crates/checker/src/lib.rs
+++ b/crates/checker/src/lib.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use r2s_bucket::challenge::ChallengeBucket;
 use r2s_database::{challenge, submission, team, user};
-use r2s_engine::{DiagnosticMarker, Engine, EngineError};
+use r2s_engine::{DiagnosticMarker, Engine, EngineError, parse_value, script_error_from_value};
 use rune::{Any, ContextError, Module, Value, runtime::Object};
 use serde::{Deserialize, Serialize};
 use tracing::debug;
@@ -164,44 +164,46 @@ impl Checker {
       None => RuneTeam::default(),
     };
     let bucket = ret2script::modules::bucket::Bucket::try_new(bucket.path())?;
-    let output = engine
-      .execute(
+    let output: Result<Value, Value> = engine
+      .execute_as(
         key,
         "check",
         (bucket, user_object, team_object, submission_object),
+        "`Result`",
       )
       .await?;
     debug!(?output, function = "check", "checker finished");
-    let output: Result<(bool, String, Option<Object>), Value> = rune::from_value(output)?;
-    if let Ok((result, message, audit)) = output {
-      let audit = if let Some(audit) = audit {
-        Some(AuditMessage {
-          peer_team: rune::from_value(
-            audit
-              .get("peer_team")
-              .ok_or(EngineError::MissingResultField(
-                "audit::peer_team".to_owned(),
-              ))?
-              .to_owned(),
-          )?,
-          reason: rune::from_value(
-            audit
-              .get("reason")
-              .ok_or(EngineError::MissingResultField(
-                "audit::peer_team".to_owned(),
-              ))?
-              .to_owned(),
-          )?,
-        })
-      } else {
-        None
-      };
-      Ok((result, message, audit))
+    let value = match output {
+      Ok(value) => value,
+      Err(error) => return Err(script_error_from_value(error)),
+    };
+    let (result, message, audit): (bool, String, Option<Object>) = parse_value(
+      value,
+      "a `(bool, String, Option<Object>)` tuple inside `Ok`",
+    )?;
+    let audit = if let Some(audit) = audit {
+      Some(AuditMessage {
+        peer_team: parse_value(
+          audit
+            .get("peer_team")
+            .ok_or(EngineError::MissingResultField(
+              "audit::peer_team".to_owned(),
+            ))?
+            .to_owned(),
+          "an `i64` field `audit.peer_team`",
+        )?,
+        reason: parse_value(
+          audit
+            .get("reason")
+            .ok_or(EngineError::MissingResultField("audit::reason".to_owned()))?
+            .to_owned(),
+          "a `String` field `audit.reason`",
+        )?,
+      })
     } else {
-      Err(EngineError::ScriptError(
-        "early returns from script".to_owned(),
-      ))
-    }
+      None
+    };
+    Ok((result, message, audit))
   }
 
   pub async fn environ(
@@ -216,22 +218,31 @@ impl Checker {
     };
     let bucket = ret2script::modules::bucket::Bucket::try_new(bucket.path())?;
     debug!("calling environ");
-    let output = engine
-      .execute(key, "environ", (bucket, user_object, team_object))
+    let output: Result<Value, Value> = engine
+      .execute_as(
+        key,
+        "environ",
+        (bucket, user_object, team_object),
+        "`Result`",
+      )
       .await?;
     debug!(?output, function = "environ", "checker finished");
-    let object: Result<Object, Value> = rune::from_value(output)?;
-    if let Ok(object) = object {
-      let mut environ = HashMap::new();
-      for (key, value) in object.iter() {
-        environ.insert(key.to_string(), rune::from_value(value.clone())?);
-      }
-      Ok(environ)
-    } else {
-      Err(EngineError::ScriptError(
-        "early returns from script".to_owned(),
-      ))
+    let value = match output {
+      Ok(value) => value,
+      Err(error) => return Err(script_error_from_value(error)),
+    };
+    let object: Object = parse_value(value, "`Object` inside `Ok`")?;
+    let mut environ = HashMap::new();
+    for (key, value) in object.iter() {
+      environ.insert(
+        key.to_string(),
+        parse_value(
+          value.clone(),
+          format!("a `String` environment variable `{key}`"),
+        )?,
+      );
     }
+    Ok(environ)
   }
 }
 

--- a/crates/cluster/src/lifecycle.rs
+++ b/crates/cluster/src/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use k8s_openapi::api::core::v1::{Container, Pod, Service, ServicePort};
-use r2s_engine::{DiagnosticMarker, Engine, EngineError};
+use r2s_engine::{DiagnosticMarker, Engine, EngineError, parse_value, script_error_from_value};
 use rune::{
   Any, ContextError, Module, Value,
   alloc::{Error as RuneAllocError, Vec as RuneVec, clone::TryClone},
@@ -908,7 +908,14 @@ impl LifecycleMapper {
         .reason()
         .map(|reason| reason.as_str().to_string()),
     )?;
-    let _output: Value = engine.execute(key, function_name, (ctx,)).await?;
+    let output: Result<Value, Value> = engine
+      .execute_as(key, function_name, (ctx,), "`Result`")
+      .await?;
+    let value = match output {
+      Ok(value) => value,
+      Err(error) => return Err(script_error_from_value(error)),
+    };
+    let _: () = parse_value(value, "`()` inside `Ok`")?;
     Ok(LifecycleExecutionStatus::Executed)
   }
 }

--- a/crates/cluster/src/traffic.rs
+++ b/crates/cluster/src/traffic.rs
@@ -1,6 +1,6 @@
 use k8s_openapi::api::core::v1::{Pod, Service};
 use kube::ResourceExt;
-use r2s_engine::{DiagnosticMarker, Engine, EngineError};
+use r2s_engine::{DiagnosticMarker, Engine, EngineError, parse_value, script_error_from_value};
 use rune::{Any, ContextError, Module, Value, alloc::clone::TryClone, runtime::Object};
 use serde::{Deserialize, Serialize};
 
@@ -139,22 +139,22 @@ impl TrafficMapper {
       .node_name
       .ok_or(ClusterError::MissingField("pod::node_name".to_owned()))?;
 
-    let output = engine
-      .execute(key, "expose", (node_name, service_info))
+    let output: Result<Value, Value> = engine
+      .execute_as(key, "expose", (node_name, service_info), "`Result`")
       .await?;
-
-    let output: Result<Object, Value> = rune::from_value(output).map_err(EngineError::from)?;
     let mut result = Vec::new();
-    if let Ok(object) = output {
-      for (key, value) in object.iter() {
-        result.push(MappedPort {
-          name: key.to_string(),
-          address: rune::from_value(value.clone()).map_err(EngineError::from)?,
-        });
+    match output {
+      Ok(value) => {
+        let object: Object = parse_value(value, "`Object` inside `Ok`")?;
+        for (key, value) in object.iter() {
+          result.push(MappedPort {
+            name: key.to_string(),
+            address: parse_value(value.clone(), "a `String` address")?,
+          });
+        }
+        Ok(result)
       }
-      Ok(result)
-    } else {
-      Err(EngineError::ScriptError("early returns from script".to_owned()).into())
+      Err(error) => Err(script_error_from_value(error)),
     }
   }
 }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -16,6 +16,7 @@ ret2script   = { workspace = true }
 rune         = { workspace = true }
 rune-modules = { workspace = true }
 serde        = { workspace = true }
+serde_json   = { workspace = true }
 thiserror    = { workspace = true }
 tokio        = { workspace = true }
 tracing      = { workspace = true }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -19,6 +19,29 @@ use crate::utils::diagnostic_to_marker;
 
 type EngineContext = (Arc<Unit>, Arc<RuntimeContext>, DateTime<Utc>);
 
+/// Parse a Rune script value according to the function's return contract.
+pub fn parse_value<T>(value: Value, expected: impl Into<String>) -> Result<T, EngineError>
+where
+  T: rune::FromValue, {
+  let actual = value.type_info();
+  rune::from_value(value).map_err(|_| EngineError::InvalidReturnType {
+    expected: expected.into(),
+    actual: actual.to_string(),
+  })
+}
+
+/// Convert a Rune script error value into the caller's error type.
+pub fn script_error_from_value<E>(error: Value) -> E
+where
+  E: From<EngineError>, {
+  let message = match rune::from_value::<String>(error.clone()) {
+    Ok(message) => message,
+    Err(_) => serde_json::to_string(&error)
+      .unwrap_or_else(|_| format!("got a non-serializable `{}` error value", error.type_info())),
+  };
+  EngineError::ScriptError(message).into()
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct Engine {
   contexts: Arc<RwLock<HashMap<String, EngineContext>>>,
@@ -162,6 +185,17 @@ impl Engine {
     let result = result.async_complete().await.into_result()?;
 
     Ok(result)
+  }
+
+  /// Execute a Rune function and parse its output according to the function's
+  /// return contract.
+  pub async fn execute_as<T>(
+    &self, key: impl AsRef<str>, func: &'static str, args: impl Args + Send,
+    expected: impl Into<String>,
+  ) -> Result<T, EngineError>
+  where
+    T: rune::FromValue, {
+    parse_value(self.execute(key, func, args).await?, expected)
   }
 
   pub async fn has_function(

--- a/crates/engine/src/traits.rs
+++ b/crates/engine/src/traits.rs
@@ -21,6 +21,8 @@ pub enum EngineError {
   ExecError(#[from] rune::runtime::VmError),
   #[error("missing fields from script result: {0}")]
   MissingResultField(String),
+  #[error("script returned an invalid type: expected {expected}, got `{actual}`")]
+  InvalidReturnType { expected: String, actual: String },
   #[error("script error: {0}")]
   ScriptError(String),
   #[error("compile error: {0}")]

--- a/crates/oauth/src/lib.rs
+++ b/crates/oauth/src/lib.rs
@@ -3,7 +3,7 @@ mod utility;
 use std::collections::HashMap;
 
 use r2s_config::auth::Config;
-use r2s_engine::{DiagnosticMarker, Engine, EngineError};
+use r2s_engine::{DiagnosticMarker, Engine, EngineError, parse_value, script_error_from_value};
 use rune::{Any, ContextError, Module, Value, runtime::Object};
 pub use traits::OAuthError;
 
@@ -24,6 +24,25 @@ pub fn module(_stdio: bool) -> Result<Module, ContextError> {
   module.ty::<RuneMap>()?;
   module.function_meta(RuneMap::get)?;
   Ok(module)
+}
+
+fn parse_output(output: Result<Value, Value>) -> Result<HashMap<String, String>, OAuthError> {
+  let value = match output {
+    Ok(value) => value,
+    Err(error) => return Err(script_error_from_value(error)),
+  };
+  let object: Object = parse_value(value, "`Object` inside `Ok`")?;
+  let _ = object
+    .get("auth_key")
+    .ok_or_else(|| OAuthError::MissingField("auth_key".to_owned()))?;
+  let mut data = HashMap::new();
+  for (key, value) in object.iter() {
+    data.insert(
+      key.to_string(),
+      parse_value(value.clone(), format!("a `String` value for `{key}`"))?,
+    );
+  }
+  Ok(data)
 }
 
 #[derive(Debug, Clone, Default)]
@@ -64,25 +83,10 @@ impl OAuth {
     let key = key.as_ref();
     let key = format!("oauth-{}", key);
     let params_object = RuneMap(params.clone());
-    let result = engine.execute(key, "login", (params_object,)).await?;
-    let output: Result<Object, Value> = rune::from_value(result).map_err(EngineError::from)?;
-    if let Ok(object) = output {
-      let _ = object
-        .get("auth_key")
-        .ok_or_else(|| OAuthError::MissingField("auth_key".to_owned()))?;
-      let mut data: HashMap<String, String> = HashMap::new();
-      for (key, value) in object.iter() {
-        data.insert(
-          key.to_string(),
-          rune::from_value(value.clone()).map_err(EngineError::from)?,
-        );
-      }
-      Ok(data)
-    } else {
-      Err(OAuthError::ScriptError(
-        "unexpected value in oauth script".to_owned(),
-      ))
-    }
+    let output: Result<Value, Value> = engine
+      .execute_as(key, "login", (params_object,), "`Result`")
+      .await?;
+    parse_output(output)
   }
 
   pub async fn bind(
@@ -93,27 +97,10 @@ impl OAuth {
     let key = format!("oauth-{}", key);
     let params_object = RuneMap(params.clone());
     let user_object = RuneMap(user.clone());
-    let result = engine
-      .execute(key, "bind", (params_object, user_object))
+    let output: Result<Value, Value> = engine
+      .execute_as(key, "bind", (params_object, user_object), "`Result`")
       .await?;
-    let output: Result<Object, Value> = rune::from_value(result).map_err(EngineError::from)?;
-    if let Ok(object) = output {
-      let _ = object
-        .get("auth_key")
-        .ok_or_else(|| OAuthError::MissingField("auth_key".to_owned()))?;
-      let mut data: HashMap<String, String> = HashMap::new();
-      for (key, value) in object.iter() {
-        data.insert(
-          key.to_string(),
-          rune::from_value(value.clone()).map_err(EngineError::from)?,
-        );
-      }
-      Ok(data)
-    } else {
-      Err(OAuthError::ScriptError(
-        "unexpected value in oauth script".to_owned(),
-      ))
-    }
+    parse_output(output)
   }
 }
 


### PR DESCRIPTION
## Summary

- Add shared Rune return-value parsing helpers to `r2s-engine`.
- Validate `Result` and `Ok` payload types with clear expected/actual type errors.
- Preserve script `Err` values as strings or JSON, with a fallback for non-serializable values.
- Apply consistent parsing to traffic, lifecycle, checker, and OAuth scripts.
- Correct the missing `audit::reason` field diagnostic.

## Testing

Ran manual integration coverage for invalid return types, string and structured errors, non-serializable values, panics, and successful returns across traffic, lifecycle, checker, and OAuth.