### PR TITLE
:bug: send basic auth when querying an authenticated registry

### DIFF
--- a/crates/cluster/src/registry.rs
+++ b/crates/cluster/src/registry.rs
@@ -69,6 +69,26 @@ impl Registry {
     ))
   }
 
+  fn authenticate(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+    match self
+      .credentials
+      .as_ref()
+      .and_then(RegistryConfig::basic_auth)
+    {
+      Some((username, password)) => request.basic_auth(username, Some(password)),
+      None => request,
+    }
+  }
+
+  async fn get(&self, url: &str) -> Result<reqwest::Response, ClusterError> {
+    Ok(
+      self
+        .authenticate(reqwest::Client::new().get(url))
+        .send()
+        .await?,
+    )
+  }
+
   pub async fn sync_repo(&mut self) -> Result<HashMap<String, Vec<String>>, ClusterError> {
     let api_base = self.api_base()?;
     let mut result: Vec<String> = Vec::new();
@@ -76,8 +96,12 @@ impl Registry {
     let mut orgs: HashMap<String, Vec<String>> = HashMap::new();
     loop {
       let res = match last {
-        ref s if s.is_empty() => reqwest::get(&format!("{api_base}/_catalog?n=1000")).await?,
-        ref s => reqwest::get(&format!("{api_base}/_catalog?n=1000&last={s}")).await?,
+        ref s if s.is_empty() => self.get(&format!("{api_base}/_catalog?n=1000")).await?,
+        ref s => {
+          self
+            .get(&format!("{api_base}/_catalog?n=1000&last={s}"))
+            .await?
+        }
       };
       let body: Repository = res.json().await?;
       let repositories = body.repositories;
@@ -104,7 +128,9 @@ impl Registry {
 
   pub async fn images(&self, repository: &str) -> Result<Vec<String>, ClusterError> {
     let api_base = self.api_base()?;
-    let res = reqwest::get(&format!("{api_base}/{repository}/tags/list")).await?;
+    let res = self
+      .get(&format!("{api_base}/{repository}/tags/list"))
+      .await?;
     let body: Tags = res.json().await?;
     Ok(body.tags)
   }
@@ -175,4 +201,45 @@ fn to_image_name(file: &str) -> String {
     .replace_all(&file, "")
     .to_string()
     .to_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn config(username: Option<&str>, password: Option<&str>) -> RegistryConfig {
+    RegistryConfig {
+      username: username.map(str::to_owned),
+      password: password.map(str::to_owned),
+      server: "registry.example.com".to_owned(),
+      insecure: true,
+      external: "registry.example.com".to_owned(),
+      enabled: Some(true),
+    }
+  }
+
+  fn authorization(config: RegistryConfig) -> Option<String> {
+    let request = Registry::new(config)
+      .authenticate(reqwest::Client::new().get("http://registry.example.com/v2/_catalog"))
+      .build()
+      .unwrap();
+    request
+      .headers()
+      .get(reqwest::header::AUTHORIZATION)
+      .and_then(|value| value.to_str().ok())
+      .map(str::to_owned)
+  }
+
+  #[test]
+  fn catalog_requests_include_basic_auth() {
+    assert_eq!(
+      authorization(config(Some("ci"), Some("secret"))).as_deref(),
+      Some("Basic Y2k6c2VjcmV0")
+    );
+  }
+
+  #[test]
+  fn catalog_requests_stay_anonymous_without_credentials() {
+    assert_eq!(authorization(config(None, None)), None);
+  }
 }

--- a/crates/config/src/cluster.rs
+++ b/crates/config/src/cluster.rs
@@ -14,6 +14,18 @@ pub struct RegistryConfig {
   pub enabled: Option<bool>,
 }
 
+impl RegistryConfig {
+  /// HTTP Basic credentials for registry API calls, when both are configured.
+  pub fn basic_auth(&self) -> Option<(&str, &str)> {
+    let username = self
+      .username
+      .as_deref()
+      .filter(|username| !username.is_empty())?;
+    let password = self.password.as_deref()?;
+    Some((username, password))
+  }
+}
+
 /// `ClusterConfig` is a configuration struct for managing service settings.
 #[derive(Serialize, Deserialize, Clone, Debug, Default, FromJsonQueryResult, PartialEq, Eq)]
 pub struct Config {
@@ -266,6 +278,19 @@ mod tests {
       Some("/var/lib/r2s/capture")
     );
     assert_eq!(merged.registry, Some(registry()));
+  }
+
+  #[test]
+  fn basic_auth_requires_username_and_password() {
+    let mut config = registry();
+    assert_eq!(config.basic_auth(), Some(("ci", "secret")));
+
+    config.username = Some(String::new());
+    assert_eq!(config.basic_auth(), None);
+
+    config.username = Some("ci".to_owned());
+    config.password = None;
+    assert_eq!(config.basic_auth(), None);
   }
 
   #[test]

--- a/crates/server/src/routes/cluster/registry.rs
+++ b/crates/server/src/routes/cluster/registry.rs
@@ -1,12 +1,13 @@
 use axum::{
   Extension, Router,
   extract::{Request, State},
-  http::{HeaderMap, HeaderValue, Uri},
+  http::{HeaderMap, HeaderValue, Uri, header},
   middleware,
   response::IntoResponse,
   routing::any,
 };
-use r2s_config::GlobalConfig;
+use base64::Engine;
+use r2s_config::{GlobalConfig, cluster::RegistryConfig};
 use r2s_database::{game, user::Permission};
 use r2s_migrator::Database;
 use tracing::{debug, info, warn};
@@ -77,26 +78,34 @@ fn infer_origin(headers: &HeaderMap) -> Result<String, ResponseError> {
   ))
 }
 
+fn apply_registry_authorization(
+  headers: &mut HeaderMap, registry: &RegistryConfig,
+) -> Result<(), ResponseError> {
+  headers.remove(header::AUTHORIZATION);
+  let Some((username, password)) = registry.basic_auth() else {
+    return Ok(());
+  };
+  let encoded = base64::engine::general_purpose::STANDARD.encode(format!("{username}:{password}"));
+  let mut value = HeaderValue::from_str(&format!("Basic {encoded}")).map_err(|err| {
+    ResponseError::InternalServerError(format!("invalid registry basic auth header: {err}"))
+  })?;
+  value.set_sensitive(true);
+  headers.insert(header::AUTHORIZATION, value);
+  Ok(())
+}
+
 async fn proxy_to_registry(
   State(config): State<GlobalConfig>, State(ref db): State<Database>,
   State(client): State<HTTPClient>, Extension(token): Extension<Token>, mut req: Request,
 ) -> Result<impl IntoResponse, ResponseError> {
   debug!(?req, "proxying frontend request");
-  let registry_config = config.cluster.clone().and_then(|v| v.registry);
-  let (protocol, registry_url) = match registry_config {
-    Some(c) => {
-      if c.insecure {
-        ("http", c.server)
-      } else {
-        ("https", c.server)
-      }
-    }
-    None => {
-      return Err(ResponseError::PreconditionFailed(String::from(
-        "internal registry is not enabled, please contact the website devops",
-      )));
-    }
+  let Some(registry) = config.cluster.clone().and_then(|v| v.registry) else {
+    return Err(ResponseError::PreconditionFailed(String::from(
+      "internal registry is not enabled, please contact the website devops",
+    )));
   };
+  let protocol = if registry.insecure { "http" } else { "https" };
+  let registry_url = registry.server.clone();
   let path = req.uri().path();
   let path_query = req
     .uri()
@@ -170,6 +179,7 @@ async fn proxy_to_registry(
   debug!(?uri, "proxying to registry url");
   *req.uri_mut() = Uri::try_from(uri)
     .map_err(|err| ResponseError::BadRequest(format!("invalid registry uri: {err}")))?;
+  apply_registry_authorization(req.headers_mut(), &registry)?;
   //req.headers_mut().remove("host");
 
   let mut resp = client


### PR DESCRIPTION
## Summary
Catalog and tag listing used `reqwest::get` and never sent `cluster.registry` credentials, so authenticated registries returned empty or failed results. The cluster registry proxy also forwarded the client's Ret2Shell `Authorization` header upstream instead of the configured registry credentials.

This change:
- Sends HTTP Basic auth on catalog and tag list requests when both username and password are configured
- Replaces client `Authorization` on proxied `/v2` requests with the configured registry Basic credentials, and marks the header as sensitive
- Leaves anonymous registries unchanged

## Testing
- `cargo test -p r2s-config basic_auth_requires_username_and_password`
- `cargo test -p r2s-cluster registry::tests`
- `cargo clippy -p r2s-config -p r2s-cluster -p r2s-server --tests -- -D warnings`
- `cargo +nightly fmt --check`

Made with [Cursor](https://cursor.com)